### PR TITLE
[DEV-1776] Added `Services` class, added `MetadataCollection` to base services

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,13 @@
 # Zepben Python SDK
 ## [0.42.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* Database readers and writes for each `BaseService` no longer accept a `MetadataCollection`, and will instead use the collection of the provided service.
+* `BaseService` and `MetadataCollection` are no longer dataclassy dataclasses. This will only affect you if you were making use of the auto generated
+  constructors to pass initial values (which didn't always work as expected anyway)
 
 ### New Features
-* None.
+* `BaseService` now contains a `MetadataCollection` to tightly couple the metadata to the associated service.
+* Added `Services`, a new class which contains a copy of each `BaseService` supported by the SDK.
 
 ### Enhancements
 * None.

--- a/src/zepben/evolve/database/sqlite/common/metadata_collection_reader.py
+++ b/src/zepben/evolve/database/sqlite/common/metadata_collection_reader.py
@@ -11,27 +11,27 @@ from zepben.evolve.database.sqlite.common.base_collection_reader import BaseColl
 from zepben.evolve.database.sqlite.common.base_database_tables import BaseDatabaseTables
 from zepben.evolve.database.sqlite.common.metadata_entry_reader import MetadataEntryReader
 from zepben.evolve.database.sqlite.tables.table_metadata_data_sources import TableMetadataDataSources
-from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
+from zepben.evolve.services.common.base_service import BaseService
 
 
 class MetadataCollectionReader(BaseCollectionReader):
     """
     Class for reading the `MetadataCollection` from the database.
 
-    :param metadata: The `MetadataCollection` to populate from the database.
+    :param service: The `BaseService` containing the `MetadataCollection` to populate from the database.
     :param tables: The tables available in the database.
     :param connection: The `Connection` to the database.
     """
 
     def __init__(
         self,
-        metadata: MetadataCollection,
+        service: BaseService,
         tables: BaseDatabaseTables,
         connection: Connection,
         reader: MetadataEntryReader = None
     ):
         super().__init__(tables, connection)
-        self._reader: MetadataEntryReader = reader if reader is not None else MetadataEntryReader(metadata)
+        self._reader: MetadataEntryReader = reader if reader is not None else MetadataEntryReader(service)
 
     def load(self) -> bool:
         return all([

--- a/src/zepben/evolve/database/sqlite/common/metadata_collection_writer.py
+++ b/src/zepben/evolve/database/sqlite/common/metadata_collection_writer.py
@@ -7,26 +7,26 @@ __all__ = ["MetadataCollectionWriter"]
 from zepben.evolve.database.sqlite.common.base_collection_writer import BaseCollectionWriter
 from zepben.evolve.database.sqlite.common.base_database_tables import BaseDatabaseTables
 from zepben.evolve.database.sqlite.common.metadata_entry_writer import MetadataEntryWriter
+from zepben.evolve.services.common.base_service import BaseService
 from zepben.evolve.services.common.meta.data_source import DataSource
-from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 
 
 class MetadataCollectionWriter(BaseCollectionWriter):
     """
     Class for writing the `MetadataCollection` to the database.
 
-    :param metadata: The `MetadataCollection` to save to the database.
+    :param service: The `BaseService` containing the `MetadataCollection` to save to the database.
     :param database_tables: The tables available in the database.
     """
 
     def __init__(
         self,
-        metadata: MetadataCollection,
+        service: BaseService,
         database_tables: BaseDatabaseTables,
         writer: MetadataEntryWriter = None
     ):
         super().__init__()
-        self._metadata: MetadataCollection = metadata
+        self._service: BaseService = service
         self._writer: MetadataEntryWriter = writer if writer is not None else MetadataEntryWriter(database_tables)
 
 
@@ -34,4 +34,4 @@ class MetadataCollectionWriter(BaseCollectionWriter):
         def log_error(it: DataSource, e: Exception):
             self._logger.error(f"Failed to save {it}: {e}")
 
-        return self._save_each(self._metadata.data_sources, self._writer.save_data_source, log_error)
+        return self._save_each(self._service.metadata.data_sources, self._writer.save_data_source, log_error)

--- a/src/zepben/evolve/database/sqlite/common/metadata_entry_reader.py
+++ b/src/zepben/evolve/database/sqlite/common/metadata_entry_reader.py
@@ -9,20 +9,20 @@ from typing import Callable
 
 from zepben.evolve.database.sqlite.extensions.result_set import ResultSet
 from zepben.evolve.database.sqlite.tables.table_metadata_data_sources import TableMetadataDataSources
+from zepben.evolve.services.common.base_service import BaseService
 from zepben.evolve.services.common.meta.data_source import DataSource
-from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 
 
 class MetadataEntryReader:
     """
     A class for reading the `MetadataCollection` entries from the database.
 
-    :param metadata: The `MetadataCollection` to populate from the database.
+    :param service: The `BaseService` containing the `MetadataCollection` to populate from the database.
     """
 
-    def __init__(self, metadata: MetadataCollection):
+    def __init__(self, service: BaseService):
         super().__init__()
-        self._metadata: MetadataCollection = metadata
+        self._service: BaseService = service
 
     def load_metadata(self, table: TableMetadataDataSources, result_set: ResultSet, set_identifier: Callable[[str], str]) -> bool:
         """
@@ -41,4 +41,4 @@ class MetadataEntryReader:
             result_set.get_instant(table.timestamp.query_index, datetime.datetime(1970, 1, 1))
         )
 
-        return self._metadata.add(data_source)
+        return self._service.metadata.add(data_source)

--- a/src/zepben/evolve/database/sqlite/customer/customer_database_reader.py
+++ b/src/zepben/evolve/database/sqlite/customer/customer_database_reader.py
@@ -11,7 +11,6 @@ from zepben.evolve.database.sqlite.common.metadata_collection_reader import Meta
 from zepben.evolve.database.sqlite.customer.customer_database_tables import CustomerDatabaseTables
 from zepben.evolve.database.sqlite.customer.customer_service_reader import CustomerServiceReader
 from zepben.evolve.database.sqlite.tables.table_version import TableVersion
-from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 from zepben.evolve.services.customer.customers import CustomerService
 
 class CustomerDatabaseReader(BaseDatabaseReader):
@@ -19,7 +18,6 @@ class CustomerDatabaseReader(BaseDatabaseReader):
     A class for reading the `CustomerService` objects and `MetadataCollection` from our customer database.
 
     :param connection: The connection to the database.
-    :param metadata: The `MetadataCollection` to populate with metadata from the database.
     :param service: The `CustomerService` to populate with CIM objects from the database.
     :param database_description: The description of the database for logging (e.g. filename).
     """
@@ -27,7 +25,6 @@ class CustomerDatabaseReader(BaseDatabaseReader):
     def __init__(
         self,
         connection: Connection,
-        metadata: MetadataCollection,
         service: CustomerService,
         database_description: str,
         tables: CustomerDatabaseTables = None,
@@ -38,7 +35,7 @@ class CustomerDatabaseReader(BaseDatabaseReader):
         tables = tables if tables is not None else CustomerDatabaseTables()
         super().__init__(
             connection,
-            metadata_reader if metadata_reader is not None else MetadataCollectionReader(metadata, tables, connection),
+            metadata_reader if metadata_reader is not None else MetadataCollectionReader(service, tables, connection),
             service_reader if service_reader is not None else CustomerServiceReader(service, tables, connection),
             service,
             database_description,

--- a/src/zepben/evolve/database/sqlite/customer/customer_database_writer.py
+++ b/src/zepben/evolve/database/sqlite/customer/customer_database_writer.py
@@ -13,7 +13,6 @@ from zepben.evolve.database.sqlite.common.base_database_writer import BaseDataba
 from zepben.evolve.database.sqlite.common.metadata_collection_writer import MetadataCollectionWriter
 from zepben.evolve.database.sqlite.customer.customer_database_tables import CustomerDatabaseTables
 from zepben.evolve.database.sqlite.customer.customer_service_writer import CustomerServiceWriter
-from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 from zepben.evolve.services.customer.customers import CustomerService
 
 
@@ -22,14 +21,12 @@ class CustomerDatabaseWriter(BaseDatabaseWriter):
     A class for writing the `CustomerService` objects and `MetadataCollection` to our customer database.
 
     :param database_file: the filename of the database to write.
-    :param metadata: The `MetadataCollection` to save to the database.
     :param service: The `CustomerService` to save to the database.
     """
 
     def __init__(
         self,
         database_file: Union[Path, str],
-        metadata: MetadataCollection,
         service: CustomerService,
         database_tables: CustomerDatabaseTables = None,
         create_metadata_writer: Callable[[], MetadataCollectionWriter] = None,
@@ -41,7 +38,7 @@ class CustomerDatabaseWriter(BaseDatabaseWriter):
         super().__init__(
             database_file,
             database_tables,
-            create_metadata_writer if create_metadata_writer is not None else lambda: MetadataCollectionWriter(metadata, database_tables),
+            create_metadata_writer if create_metadata_writer is not None else lambda: MetadataCollectionWriter(service, database_tables),
             create_service_writer if create_service_writer is not None else lambda: CustomerServiceWriter(service, database_tables),
             get_connection if get_connection is not None else sqlite3.connect
         )

--- a/src/zepben/evolve/database/sqlite/diagram/diagram_database_reader.py
+++ b/src/zepben/evolve/database/sqlite/diagram/diagram_database_reader.py
@@ -11,7 +11,6 @@ from zepben.evolve.database.sqlite.common.metadata_collection_reader import Meta
 from zepben.evolve.database.sqlite.diagram.diagram_database_tables import DiagramDatabaseTables
 from zepben.evolve.database.sqlite.diagram.diagram_service_reader import DiagramServiceReader
 from zepben.evolve.database.sqlite.tables.table_version import TableVersion
-from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 from zepben.evolve.services.diagram.diagrams import DiagramService
 
 
@@ -20,7 +19,6 @@ class DiagramDatabaseReader(BaseDatabaseReader):
     A class for reading the `DiagramService` objects and `MetadataCollection` from our diagram database.
 
     :param connection: The connection to the database.
-    :param metadata: The `MetadataCollection` to populate with metadata from the database.
     :param service: The `DiagramService` to populate with CIM objects from the database.
     :param database_description: The description of the database for logging (e.g. filename).
     """
@@ -28,7 +26,6 @@ class DiagramDatabaseReader(BaseDatabaseReader):
     def __init__(
         self,
         connection: Connection,
-        metadata: MetadataCollection,
         service: DiagramService,
         database_description: str,
         tables: DiagramDatabaseTables = None,
@@ -39,7 +36,7 @@ class DiagramDatabaseReader(BaseDatabaseReader):
         tables = tables if tables is not None else DiagramDatabaseTables()
         super().__init__(
             connection,
-            metadata_reader if metadata_reader is not None else MetadataCollectionReader(metadata, tables, connection),
+            metadata_reader if metadata_reader is not None else MetadataCollectionReader(service, tables, connection),
             service_reader if service_reader is not None else DiagramServiceReader(service, tables, connection),
             service,
             database_description,

--- a/src/zepben/evolve/database/sqlite/diagram/diagram_database_writer.py
+++ b/src/zepben/evolve/database/sqlite/diagram/diagram_database_writer.py
@@ -13,7 +13,6 @@ from zepben.evolve.database.sqlite.common.base_database_writer import BaseDataba
 from zepben.evolve.database.sqlite.common.metadata_collection_writer import MetadataCollectionWriter
 from zepben.evolve.database.sqlite.diagram.diagram_database_tables import DiagramDatabaseTables
 from zepben.evolve.database.sqlite.diagram.diagram_service_writer import DiagramServiceWriter
-from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 from zepben.evolve.services.diagram.diagrams import DiagramService
 
 
@@ -22,14 +21,12 @@ class DiagramDatabaseWriter(BaseDatabaseWriter):
     A class for writing the `DiagramService` objects and `MetadataCollection` to our diagram database.
 
     :param database_file: the filename of the database to write.
-    :param metadata: The `MetadataCollection` to save to the database.
     :param service: The `DiagramService` to save to the database.
     """
 
     def __init__(
         self,
         database_file: Union[Path, str],
-        metadata: MetadataCollection,
         service: DiagramService,
         database_tables: DiagramDatabaseTables = None,
         create_metadata_writer: Callable[[], MetadataCollectionWriter] = None,
@@ -40,7 +37,7 @@ class DiagramDatabaseWriter(BaseDatabaseWriter):
         super().__init__(
             database_file,
             database_tables,
-            create_metadata_writer if create_metadata_writer is not None else lambda: MetadataCollectionWriter(metadata, database_tables),
+            create_metadata_writer if create_metadata_writer is not None else lambda: MetadataCollectionWriter(service, database_tables),
             create_service_writer if create_service_writer is not None else lambda: DiagramServiceWriter(service, database_tables),
             get_connection if get_connection is not None else sqlite3.connect
         )

--- a/src/zepben/evolve/database/sqlite/network/network_database_reader.py
+++ b/src/zepben/evolve/database/sqlite/network/network_database_reader.py
@@ -14,7 +14,6 @@ from zepben.evolve.database.sqlite.tables.table_version import TableVersion
 from zepben.evolve.model.cim.iec61970.base.core.equipment import Equipment
 from zepben.evolve.model.cim.iec61970.base.core.equipment_container import Feeder
 from zepben.evolve.model.cim.iec61970.base.wires.energy_source import EnergySource
-from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 from zepben.evolve.services.network.network_service import NetworkService, connected_equipment
 
 __all__ = ["NetworkDatabaseReader"]
@@ -36,7 +35,6 @@ class NetworkDatabaseReader(BaseDatabaseReader):
       remove the split database logic - Check `UpgradeRunner` to see if this is still required.
 
     :param connection: The connection to the database.
-    :param metadata: The `MetadataCollection` to populate with metadata from the database.
     :param service: The `NetworkService` to populate with CIM objects from the database.
     :param database_description: The description of the database for logging (e.g. filename).
     """
@@ -44,7 +42,6 @@ class NetworkDatabaseReader(BaseDatabaseReader):
     def __init__(
         self,
         connection: Connection,
-        metadata: MetadataCollection,
         service: NetworkService,
         database_description: str,
         tables: NetworkDatabaseTables = NetworkDatabaseTables(),
@@ -59,7 +56,7 @@ class NetworkDatabaseReader(BaseDatabaseReader):
     ):
         super().__init__(
             connection,
-            metadata_reader if metadata_reader else MetadataCollectionReader(metadata, tables, connection),
+            metadata_reader if metadata_reader else MetadataCollectionReader(service, tables, connection),
             service_reader if service_reader else NetworkServiceReader(service, tables, connection),
             service,
             database_description,

--- a/src/zepben/evolve/database/sqlite/network/network_database_writer.py
+++ b/src/zepben/evolve/database/sqlite/network/network_database_writer.py
@@ -13,7 +13,6 @@ from zepben.evolve.database.sqlite.common.base_database_writer import BaseDataba
 from zepben.evolve.database.sqlite.common.metadata_collection_writer import MetadataCollectionWriter
 from zepben.evolve.database.sqlite.network.network_database_tables import NetworkDatabaseTables
 from zepben.evolve.database.sqlite.network.network_service_writer import NetworkServiceWriter
-from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 from zepben.evolve.services.network.network_service import NetworkService
 
 
@@ -22,14 +21,12 @@ class NetworkDatabaseWriter(BaseDatabaseWriter):
     A class for writing the `NetworkService` objects and `MetadataCollection` to our network database.
 
     :param database_file: the filename of the database to write.
-    :param metadata: The `MetadataCollection` to save to the database.
     :param service: The `NetworkService` to save to the database.
     """
 
     def __init__(
         self,
         database_file: Union[Path, str],
-        metadata: MetadataCollection,
         service: NetworkService,
         database_tables: NetworkDatabaseTables = NetworkDatabaseTables(),
         create_metadata_writer: Callable[[Connection], MetadataCollectionWriter] = None,
@@ -39,7 +36,7 @@ class NetworkDatabaseWriter(BaseDatabaseWriter):
         super().__init__(
             database_file,
             database_tables,
-            create_metadata_writer if create_metadata_writer is not None else lambda: MetadataCollectionWriter(metadata, database_tables),
+            create_metadata_writer if create_metadata_writer is not None else lambda: MetadataCollectionWriter(service, database_tables),
             create_service_writer if create_service_writer is not None else lambda: NetworkServiceWriter(service, database_tables),
             get_connection if get_connection is not None else sqlite3.connect
         )

--- a/src/zepben/evolve/services/common/meta/metadata_collection.py
+++ b/src/zepben/evolve/services/common/meta/metadata_collection.py
@@ -4,16 +4,16 @@
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from typing import List, Generator
 
-from dataclassy import dataclass
-
-from zepben.evolve import DataSource
+from zepben.evolve.services.common.meta.data_source import DataSource
 
 __all__ = ["MetadataCollection"]
 
 
-@dataclass(slots=True)
-class MetadataCollection(object):
-    _data_sources: List[DataSource] = list()
+class MetadataCollection:
+
+    def __init__(self):
+        super().__init__()
+        self._data_sources: List[DataSource] = []
 
     @property
     def data_sources(self) -> Generator[DataSource, None, None]:

--- a/src/zepben/evolve/services/customer/customers.py
+++ b/src/zepben/evolve/services/customer/customers.py
@@ -2,14 +2,21 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+__all__ = ["CustomerService"]
+
+from typing import Optional
 
 from zepben.evolve.services.common.base_service import BaseService
-
-__all__ = ["CustomerService"]
+from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 
 
 class CustomerService(BaseService):
     """
     Used to store Customer related types.
     """
-    name: str = "customer"
+
+    def __init__(
+        self,
+        metadata: Optional[MetadataCollection] = None
+    ):
+        super().__init__("customer", metadata)

--- a/src/zepben/evolve/services/diagram/diagrams.py
+++ b/src/zepben/evolve/services/diagram/diagrams.py
@@ -2,24 +2,26 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+__all__ = ["DiagramService"]
 
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from zepben.evolve.model.cim.iec61970.base.diagramlayout.diagram_layout import DiagramObject
 from zepben.evolve.services.common.base_service import BaseService
-
-__all__ = ["DiagramService"]
+from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 
 
 class DiagramService(BaseService):
-    name: str = "diagram"
-    _diagram_objects_by_diagram_mrid: Dict[str, Dict[str, DiagramObject]] = dict()
-    _diagram_objects_by_identified_object_mrid: Dict[str, Dict[str, DiagramObject]] = dict()
-    _diagram_object_indexes: List[Dict[str, Dict[str, DiagramObject]]] = list()
 
-    def __init__(self):
-        self._diagram_object_indexes.append(self._diagram_objects_by_identified_object_mrid)
-        self._diagram_object_indexes.append(self._diagram_objects_by_diagram_mrid)
+    def __init__(
+        self,
+        metadata: Optional[MetadataCollection] = None
+    ):
+        super().__init__("diagram", metadata)
+
+        self._diagram_objects_by_diagram_mrid: Dict[str, Dict[str, DiagramObject]] = dict()
+        self._diagram_objects_by_identified_object_mrid: Dict[str, Dict[str, DiagramObject]] = dict()
+        self._diagram_object_indexes: List[Dict[str, Dict[str, DiagramObject]]] = list()
 
     def get_diagram_objects(self, mrid: str) -> List[DiagramObject]:
         """

--- a/src/zepben/evolve/services/measurement/measurements.py
+++ b/src/zepben/evolve/services/measurement/measurements.py
@@ -4,6 +4,8 @@
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from __future__ import annotations
 
+__all__ = ["MeasurementService"]
+
 from typing import List, Optional, Generator, TYPE_CHECKING
 
 from zepben.evolve import MeasurementValue
@@ -11,14 +13,12 @@ from zepben.evolve import MeasurementValue
 if TYPE_CHECKING:
     from zepben.evolve import IdentifiedObject
 
-from zepben.evolve.services.common.base_service import BaseService
 
-__all__ = ["MeasurementService"]
+class MeasurementService:
 
-
-class MeasurementService(BaseService):
-    name: str = "measurement"
-    _measurements: List[MeasurementValue] = []
+    def __init__(self):
+        super().__init__()
+        self._measurements: List[MeasurementValue] = []
 
     def add(self, value: MeasurementValue):
         self._measurements.append(value)

--- a/src/zepben/evolve/services/network/network_service.py
+++ b/src/zepben/evolve/services/network/network_service.py
@@ -5,22 +5,23 @@
 
 from __future__ import annotations
 
+__all__ = ["connect", "connected_terminals", "connected_equipment", "NetworkService"]
+
 import itertools
 import logging
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, List, Union, Iterable
-
-from zepben.evolve.model.cim.iec61970.base.wires.single_phase_kind import SinglePhaseKind
-from zepben.evolve.model.cim.iec61970.base.core.phase_code import PhaseCode
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Union, Iterable, Optional
 
 from zepben.evolve.model.cim.iec61970.base.core.connectivity_node import ConnectivityNode
+from zepben.evolve.model.cim.iec61970.base.core.phase_code import PhaseCode
+from zepben.evolve.model.cim.iec61970.base.wires.single_phase_kind import SinglePhaseKind
 from zepben.evolve.services.common.base_service import BaseService
+from zepben.evolve.services.common.meta.metadata_collection import MetadataCollection
 from zepben.evolve.services.network.tracing.connectivity.terminal_connectivity_connected import TerminalConnectivityConnected
-from pathlib import Path
 if TYPE_CHECKING:
     from zepben.evolve import Terminal, SinglePhaseKind, ConnectivityResult, Measurement, ConductingEquipment
 
-__all__ = ["connect", "connected_terminals", "connected_equipment", "NetworkService"]
 logger = logging.getLogger(__name__)
 TRACED_NETWORK_FILE = str(Path.home().joinpath(Path("traced.json")))
 
@@ -103,12 +104,16 @@ class NetworkService(BaseService):
         metrics_store : Storage for meter measurement data associated with this network.
     """
 
-    name: str = "network"
-    _connectivity_nodes: Dict[str, ConnectivityNode] = dict()
-    _auto_cn_index: int = 0
-    _measurements: Dict[str, List[Measurement]] = []
+    def __init__(
+        self,
+        metadata: Optional[MetadataCollection] = None
+    ):
+        super().__init__("network", metadata)
 
-    def __init__(self):
+        self._connectivity_nodes: Dict[str, ConnectivityNode] = dict()
+        self._auto_cn_index: int = 0
+        self._measurements: Dict[str, List[Measurement]] = {}
+
         self._objects_by_type[ConnectivityNode] = self._connectivity_nodes
 
     def get_measurements(self, mrid: str, t: type) -> List[Measurement]:

--- a/src/zepben/evolve/services/services.py
+++ b/src/zepben/evolve/services/services.py
@@ -1,0 +1,48 @@
+#  Copyright 2024 Zeppelin Bend Pty Ltd
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import Optional
+
+from zepben.evolve import NetworkService, DiagramService, CustomerService
+
+
+class Services:
+    """
+    A convenience class for storing the data supported by the SDK.
+
+    :param network_service: An optional `NetworkService` to add to the services, otherwise an empty `NetworkService` will be created.
+    :param diagram_service: An optional `NetworkService` to add to the services, otherwise an empty `NetworkService` will be created.
+    :param customer_service: An optional `NetworkService` to add to the services, otherwise an empty `NetworkService` will be created.
+    """
+
+    def __init__(
+        self,
+        network_service: Optional[NetworkService] = NetworkService(),
+        diagram_service: Optional[DiagramService] = DiagramService(),
+        customer_service: Optional[CustomerService] = CustomerService()
+    ):
+        super().__init__()
+        self.network_service = network_service
+        """The `NetworkService` of these services."""
+
+        self.diagram_service = diagram_service
+        """The `DiagramService` of these services."""
+
+        self.customer_service = customer_service
+        """The `CustomerService` of these services."""
+
+    def __iter__(self):
+        self._iter_index = 0
+        return self
+
+    def __next__(self):
+        self._iter_index += 1
+        if self._iter_index == 1:
+            return self.network_service
+        elif self._iter_index == 2:
+            return self.diagram_service
+        elif self._iter_index == 3:
+            return self.customer_service
+        else:
+            raise StopIteration

--- a/test/database/sqlite/customer/test_customer_database_reader.py
+++ b/test/database/sqlite/customer/test_customer_database_reader.py
@@ -34,7 +34,6 @@ class TestCustomerDatabaseReader:
 
         self.reader = CustomerDatabaseReader(
             self.connection,
-            Mock(),  # The metadata is unused if we provide a metadata_reader.
             self.service,
             self.database_file,
             Mock(),  # tables should not be used if we provide the rest of the parameters, so provide a mockk that will throw if used.

--- a/test/database/sqlite/customer/test_customer_database_schema.py
+++ b/test/database/sqlite/customer/test_customer_database_schema.py
@@ -10,7 +10,7 @@ from hypothesis import given, settings, HealthCheck
 from cim.cim_creators import create_organisation, create_customer, create_customer_agreement, create_pricing_structure, create_tariffs
 from database.sqlite.common.cim_database_schema_common_tests import CimDatabaseSchemaCommonTests, TComparator, TService, TReader, TWriter
 from database.sqlite.schema_utils import SchemaNetworks
-from zepben.evolve import MetadataCollection, IdentifiedObject, CustomerAgreement, PricingStructure, Tariff, Organisation, Customer, CustomerDatabaseReader, \
+from zepben.evolve import IdentifiedObject, CustomerAgreement, PricingStructure, Tariff, Organisation, Customer, CustomerDatabaseReader, \
     CustomerDatabaseWriter, CustomerService
 from zepben.evolve.services.customer.customer_service_comparator import CustomerServiceComparator
 
@@ -23,11 +23,11 @@ class TestCustomerDatabaseSchema(CimDatabaseSchemaCommonTests[CustomerService, C
     def create_service(self) -> TService:
         return CustomerService()
 
-    def create_writer(self, filename: str, metadata: MetadataCollection, service: TService) -> TWriter:
-        return CustomerDatabaseWriter(filename, metadata, service)
+    def create_writer(self, filename: str, service: TService) -> TWriter:
+        return CustomerDatabaseWriter(filename, service)
 
-    def create_reader(self, connection: Connection, metadata: MetadataCollection, service: TService, database_description: str) -> TReader:
-        return CustomerDatabaseReader(connection, metadata, service, database_description)
+    def create_reader(self, connection: Connection, service: TService, database_description: str) -> TReader:
+        return CustomerDatabaseReader(connection, service, database_description)
 
     def create_comparator(self) -> TComparator:
         return CustomerServiceComparator()

--- a/test/database/sqlite/diagram/test_diagram_database_reader.py
+++ b/test/database/sqlite/diagram/test_diagram_database_reader.py
@@ -34,7 +34,6 @@ class TestDiagramDatabaseReader:
 
         self.reader = DiagramDatabaseReader(
             self.connection,
-            Mock(),  # The metadata is unused if we provide a metadata_reader.
             self.service,
             self.database_file,
             Mock(),  # tables should not be used if we provide the rest of the parameters, so provide a mockk that will throw if used.

--- a/test/database/sqlite/diagram/test_diagram_database_schema.py
+++ b/test/database/sqlite/diagram/test_diagram_database_schema.py
@@ -10,7 +10,7 @@ from hypothesis import given, settings, HealthCheck
 from cim.cim_creators import create_diagram, create_diagram_object
 from database.sqlite.common.cim_database_schema_common_tests import CimDatabaseSchemaCommonTests, TComparator, TService, TReader, TWriter
 from database.sqlite.schema_utils import SchemaNetworks
-from zepben.evolve import MetadataCollection, IdentifiedObject, Diagram, DiagramObject, DiagramDatabaseReader, DiagramDatabaseWriter, DiagramService
+from zepben.evolve import IdentifiedObject, Diagram, DiagramObject, DiagramDatabaseReader, DiagramDatabaseWriter, DiagramService
 from zepben.evolve.services.diagram.diagram_service_comparator import DiagramServiceComparator
 
 T = TypeVar("T", bound=IdentifiedObject)
@@ -22,11 +22,11 @@ class TestDiagramDatabaseSchema(CimDatabaseSchemaCommonTests[DiagramService, Dia
     def create_service(self) -> TService:
         return DiagramService()
 
-    def create_writer(self, filename: str, metadata: MetadataCollection, service: TService) -> TWriter:
-        return DiagramDatabaseWriter(filename, metadata, service)
+    def create_writer(self, filename: str, service: TService) -> TWriter:
+        return DiagramDatabaseWriter(filename, service)
 
-    def create_reader(self, connection: Connection, metadata: MetadataCollection, service: TService, database_description: str) -> TReader:
-        return DiagramDatabaseReader(connection, metadata, service, database_description)
+    def create_reader(self, connection: Connection, service: TService, database_description: str) -> TReader:
+        return DiagramDatabaseReader(connection, service, database_description)
 
     def create_comparator(self) -> TComparator:
         return DiagramServiceComparator()

--- a/test/database/sqlite/network/test_network_database_reader.py
+++ b/test/database/sqlite/network/test_network_database_reader.py
@@ -40,7 +40,6 @@ class TestNetworkDatabaseReader:
 
         self.reader = NetworkDatabaseReader(
             self.connection,
-            Mock(),  # The metadata is unused if we provide a metadata_reader.
             self.service,
             self.database_file,
             Mock(),  # tables should not be used if we provide the rest of the parameters, so provide a mockk that will throw if used.

--- a/test/database/sqlite/network/test_network_database_schema.py
+++ b/test/database/sqlite/network/test_network_database_schema.py
@@ -12,7 +12,7 @@ from sqlite3 import Connection
 
 import pytest
 from hypothesis import given, settings, HealthCheck, assume
-from zepben.evolve import MetadataCollection, IdentifiedObject, AcLineSegment, CableInfo, NoLoadTest, OpenCircuitTest, OverheadWireInfo, PowerTransformerInfo, \
+from zepben.evolve import IdentifiedObject, AcLineSegment, CableInfo, NoLoadTest, OpenCircuitTest, OverheadWireInfo, PowerTransformerInfo, \
     ShortCircuitTest, ShuntCompensatorInfo, TransformerEndInfo, TransformerTankInfo, AssetOwner, Pole, Streetlight, Meter, UsagePoint, Location, Organisation, \
     OperationalRestriction, FaultIndicator, BaseVoltage, ConnectivityNode, Feeder, GeographicalRegion, Site, SubGeographicalRegion, Substation, Terminal, \
     EquivalentBranch, Accumulator, Analog, Control, Discrete, RemoteControl, RemoteSource, BatteryUnit, PhotoVoltaicUnit, \
@@ -50,11 +50,11 @@ class TestNetworkDatabaseSchema(CimDatabaseSchemaCommonTests[NetworkService, Net
     def create_service(self) -> TService:
         return NetworkService()
 
-    def create_writer(self, filename: str, metadata: MetadataCollection, service: TService) -> TWriter:
-        return NetworkDatabaseWriter(filename, metadata, service)
+    def create_writer(self, filename: str, service: TService) -> TWriter:
+        return NetworkDatabaseWriter(filename, service)
 
-    def create_reader(self, connection: Connection, metadata: MetadataCollection, service: TService, database_description: str) -> TReader:
-        return NetworkDatabaseReader(connection, metadata, service, database_description)
+    def create_reader(self, connection: Connection, service: TService, database_description: str) -> TReader:
+        return NetworkDatabaseReader(connection, service, database_description)
 
     def create_comparator(self) -> TComparator:
         return NetworkServiceComparator()
@@ -77,11 +77,10 @@ class TestNetworkDatabaseSchema(CimDatabaseSchemaCommonTests[NetworkService, Net
 
         assert os.path.isfile(database_file), "database must exist"
 
-        metadata = MetadataCollection()
         network_service = NetworkService()
 
         with contextlib.closing(sqlite3.connect(database_file)) as connection:
-            assert await NetworkDatabaseReader(connection, metadata, network_service, database_file).load(), "Database should have loaded"
+            assert await NetworkDatabaseReader(connection, network_service, database_file).load(), "Database should have loaded"
 
         print("Sleeping...")
         try:
@@ -584,7 +583,7 @@ class TestNetworkDatabaseSchema(CimDatabaseSchemaCommonTests[NetworkService, Net
         write_service = NetworkService()
         write_service.add(Location(mrid="loc1", main_address=StreetAddress(town_detail=TownDetail(), street_detail=StreetDetail())))
 
-        def validate(service: NetworkService, _: MetadataCollection):
+        def validate(service: NetworkService):
             assert service.get("loc1", Location).main_address == StreetAddress(), \
                 "Expected a default street address as blank parts should have been removed during teh database read"
 

--- a/test/services/common/test_base_service.py
+++ b/test/services/common/test_base_service.py
@@ -168,7 +168,7 @@ def test_add_resolves_reverse_relationship():
     or1.add_equipment(eq1)
 
     # noinspection PyArgumentList
-    ns = NetworkService(name="test")
+    ns = NetworkService()
     # noinspection PyUnresolvedReferences
     ns.add_from_pb(eq1.to_pb())
     # noinspection PyUnresolvedReferences

--- a/test/services/test_services.py
+++ b/test/services/test_services.py
@@ -1,0 +1,26 @@
+#  Copyright 2024 Zeppelin Bend Pty Ltd
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from zepben.evolve import NetworkService, DiagramService, CustomerService
+from zepben.evolve.services.services import Services
+
+expected_ns = NetworkService()
+expected_ds = DiagramService()
+expected_cs = CustomerService()
+
+services = Services(expected_ns, expected_ds, expected_cs)
+
+
+def test_accessors():
+    assert services.network_service is expected_ns
+    assert services.diagram_service is expected_ds
+    assert services.customer_service is expected_cs
+
+
+def test_supports_destructuring():
+    (ns, ds, cs) = services
+
+    assert ns is expected_ns
+    assert ds is expected_ds
+    assert cs is expected_cs


### PR DESCRIPTION
# Description

Added `Services` class, added `MetadataCollection` to base services and updated database readers/writers to use relocated metadata.

Side effect of doing this was changing `BaseService` and `MetadataCollection` to no longer implement `dataclassy.dataclass` in order to get a separate instance of the metadata per service instance.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

* Database readers and writes for each `BaseService` no longer accept a `MetadataCollection`.
* `BaseService` and `MetadataCollection` are no longer dataclassy dataclasses.
