### PR TITLE
[DEV-1977] current states container enhancement

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * `QueryNetworkStateService.on_get_current_states` must now return a stream of `CurrentStateEventBatch` rather than just the events themselves.
 * `AcLineSegment.per_length_sequence_impedance` has been corrected to `per_length_impedance`. This has been done in a non-breaking way, however the public 
   resolver `Resolvers.per_length_sequence_impedance` is now `Resolvers.per_length_impedance`, correctly reflecting the CIM relationship.
+* Removed `get_current_equipment_for_feeder` implementation for `NetworkConsumerClient` as its functionality is now incorporated in `get_equipment_for_container`.
 
 ### New Features
 * Added `BatchNotProcessed` current state response. This is used to indicate a batch has been ignored, rather than just returning a `BatchSuccessful`.
@@ -31,6 +32,8 @@
 * Added collection of `BatteryControl` to `BatteryUnit`
 * Added collection of `EndDeviceFunctionKind` to `EndDevice`
 * Added an unordered collection comparator.
+* Added the energized relationship for the current state of network between `Feeder` and `LvFeeder`.
+* Updated `NetworkConsumerClient` `get_equipment_for_container/s` to allow requesting normal, current or all equipments.
 
 ### Fixes
 * None.

--- a/src/zepben/evolve/model/cim/iec61970/base/core/equipment_container.py
+++ b/src/zepben/evolve/model/cim/iec61970/base/core/equipment_container.py
@@ -212,6 +212,9 @@ class Feeder(EquipmentContainer):
     _normal_energized_lv_feeders: Optional[Dict[str, LvFeeder]] = None
     """The LV feeders that are energized by this feeder in the normal state of the network."""
 
+    _current_energized_lv_feeders: Optional[Dict[str, LvFeeder]] = None
+    """The LV feeders that are energized by this feeder in the current state of the network."""
+
     def __init__(
         self,
         normal_head_terminal: Terminal = None,
@@ -309,13 +312,13 @@ class Feeder(EquipmentContainer):
     @property
     def normal_energized_lv_feeders(self) -> Generator[LvFeeder, None, None]:
         """
-        The LV feeders that are energized by this feeder.
+        The LV feeders that are normally energized by this feeder.
         """
         return ngen(self._normal_energized_lv_feeders.values() if self._normal_energized_lv_feeders is not None else self._normal_energized_lv_feeders)
 
     def num_normal_energized_lv_feeders(self) -> int:
         """
-        Get the number of LV feeders that are energized by this feeder.
+        Get the number of LV feeders that are normally energized by this feeder.
         """
         return nlen(self._normal_energized_lv_feeders)
 
@@ -365,6 +368,67 @@ class Feeder(EquipmentContainer):
         @return: This `Feeder` for fluent use.
         """
         self._normal_energized_lv_feeders = None
+        return self
+
+    @property
+    def current_energized_lv_feeders(self) -> Generator[LvFeeder, None, None]:
+        """
+        The LV feeders that are currently energized by this feeder.
+        """
+        return ngen(self._current_energized_lv_feeders.values() if self._current_energized_lv_feeders is not None else self._current_energized_lv_feeders)
+
+    def num_current_energized_lv_feeders(self) -> int:
+        """
+        Get the number of LV feeders that are currently energized by this feeder.
+        """
+        return nlen(self._current_energized_lv_feeders)
+
+    def get_current_energized_lv_feeder(self, mrid: str) -> LvFeeder:
+        """
+        Energized LvFeeder in the current state of the network.
+
+        @param mrid: The mrid of the `LvFeeder`.
+        @return A matching `LvFeeder` that is energized by this `Feeder` in the current state of the network.
+        @raise A `KeyError` if no matching `LvFeeder` was found.
+        """
+        if not self._current_energized_lv_feeders:
+            raise KeyError(mrid)
+        try:
+            return self._current_energized_lv_feeders[mrid]
+        except AttributeError:
+            raise KeyError(mrid)
+
+    def add_current_energized_lv_feeder(self, lv_feeder: LvFeeder) -> Feeder:
+        """
+        Associate this `Feeder` with an `LvFeeder` in the current state of the network.
+
+        @param lv_feeder: the LV feeder to associate with this feeder in the current state of the network.
+        @return: This `Feeder` for fluent use.
+        """
+        if self._validate_reference(lv_feeder, self.get_current_energized_lv_feeder, "An LvFeeder"):
+            return self
+        self._current_energized_lv_feeders = dict() if self._current_energized_lv_feeders is None else self._current_energized_lv_feeders
+        self._current_energized_lv_feeders[lv_feeder.mrid] = lv_feeder
+        return self
+
+    def remove_current_energized_lv_feeder(self, lv_feeder: LvFeeder) -> Feeder:
+        """
+        Disassociate this `Feeder` from an `LvFeeder` in the current state of the network.
+
+        @param lv_feeder: the LV feeder to disassociate from this feeder in the current state of the network.
+        @return: This `Feeder` for fluent use.
+        @raise: A `ValueError` if `lv_feeder` is not found in the current energized lv feeders collection.
+        """
+        self._current_energized_lv_feeders = safe_remove_by_id(self._current_energized_lv_feeders, lv_feeder)
+        return self
+
+    def clear_current_energized_lv_feeders(self) -> Feeder:
+        """
+        Clear all `LvFeeder`s associated with `Feeder` in the current state of the network.
+
+        @return: This `Feeder` for fluent use.
+        """
+        self._current_energized_lv_feeders = None
         return self
 
 

--- a/src/zepben/evolve/model/cim/iec61970/base/core/equipment_container.py
+++ b/src/zepben/evolve/model/cim/iec61970/base/core/equipment_container.py
@@ -221,6 +221,7 @@ class Feeder(EquipmentContainer):
         normal_energizing_substation: Substation = None,
         current_equipment: List[Equipment] = None,
         normal_energized_lv_feeders: List[LvFeeder] = None,
+        current_energized_lv_feeders: List[LvFeeder] = None,
         **kwargs
     ):
         super(Feeder, self).__init__(**kwargs)
@@ -234,6 +235,9 @@ class Feeder(EquipmentContainer):
         if current_equipment:
             for eq in current_equipment:
                 self.add_current_equipment(eq)
+        if current_energized_lv_feeders:
+            for lv_feeder in current_energized_lv_feeders:
+                self.add_current_energized_lv_feeder(lv_feeder)
 
     @property
     def normal_head_terminal(self) -> Optional[Terminal]:

--- a/src/zepben/evolve/model/cim/iec61970/base/core/equipment_container.py
+++ b/src/zepben/evolve/model/cim/iec61970/base/core/equipment_container.py
@@ -318,7 +318,7 @@ class Feeder(EquipmentContainer):
         """
         The LV feeders that are normally energized by this feeder.
         """
-        return ngen(self._normal_energized_lv_feeders.values() if self._normal_energized_lv_feeders is not None else self._normal_energized_lv_feeders)
+        return ngen(self._normal_energized_lv_feeders.values() if self._normal_energized_lv_feeders is not None else None)
 
     def num_normal_energized_lv_feeders(self) -> int:
         """

--- a/src/zepben/evolve/model/cim/iec61970/infiec61970/feeder/lv_feeder.py
+++ b/src/zepben/evolve/model/cim/iec61970/infiec61970/feeder/lv_feeder.py
@@ -28,17 +28,18 @@ class LvFeeder(EquipmentContainer):
     _normal_energizing_feeders: Optional[Dict[str, Feeder]] = None
     """The feeders that energize this LV feeder in the normal state of the network."""
 
-    _current_energizing_feeders: Optional[Dict[str, Feeder]] = None
-    """The feeders that energize this LV feeder in the current state of the network."""
-
     _current_equipment: Optional[Dict[str, Equipment]] = None
     """The equipment contained in this LvFeeder in the current state of the network."""
+
+    _current_energizing_feeders: Optional[Dict[str, Feeder]] = None
+    """The feeders that energize this LV feeder in the current state of the network."""
 
     def __init__(
         self,
         normal_head_terminal: Terminal = None,
         normal_energizing_feeders: List[Feeder] = None,
         current_equipment: List[Equipment] = None,
+        current_energizing_feeders: List[Feeder] = None,
         **kwargs
     ):
         super(LvFeeder, self).__init__(**kwargs)
@@ -50,6 +51,10 @@ class LvFeeder(EquipmentContainer):
         if current_equipment:
             for eq in current_equipment:
                 self.add_current_equipment(eq)
+        if current_energizing_feeders:
+            for feeder in current_energizing_feeders:
+                self.add_current_energizing_feeder(feeder)
+
 
     @property
     def normal_head_terminal(self) -> Optional[Terminal]:

--- a/src/zepben/evolve/model/cim/iec61970/infiec61970/feeder/lv_feeder.py
+++ b/src/zepben/evolve/model/cim/iec61970/infiec61970/feeder/lv_feeder.py
@@ -26,6 +26,10 @@ class LvFeeder(EquipmentContainer):
     """The normal head terminal or terminals of this LvFeeder"""
 
     _normal_energizing_feeders: Optional[Dict[str, Feeder]] = None
+    """The feeders that energize this LV feeder in the normal state of the network."""
+
+    _current_energizing_feeders: Optional[Dict[str, Feeder]] = None
+    """The feeders that energize this LV feeder in the current state of the network."""
 
     _current_equipment: Optional[Dict[str, Equipment]] = None
     """The equipment contained in this LvFeeder in the current state of the network."""
@@ -64,13 +68,13 @@ class LvFeeder(EquipmentContainer):
     @property
     def normal_energizing_feeders(self) -> Generator[Feeder, None, None]:
         """
-        The HV/MV feeders that energize this LV feeder.
+        The HV/MV feeders that normally energize this LV feeder.
         """
         return ngen(self._normal_energizing_feeders.values() if self._normal_energizing_feeders is not None else None)
 
     def num_normal_energizing_feeders(self) -> int:
         """
-        Get the number of HV/MV feeders that energize this LV feeder.
+        Get the number of HV/MV feeders that normally energize this LV feeder.
         """
         return nlen(self._normal_energizing_feeders)
 
@@ -120,6 +124,67 @@ class LvFeeder(EquipmentContainer):
         @return: This `LvFeeder` for fluent use.
         """
         self._normal_energizing_feeders = None
+        return self
+
+    @property
+    def current_energizing_feeders(self) -> Generator[Feeder, None, None]:
+        """
+        The HV/MV feeders that currently energize this LV feeder.
+        """
+        return ngen(self._current_energizing_feeders.values() if self._current_energizing_feeders is not None else None)
+
+    def num_current_energizing_feeders(self) -> int:
+        """
+        Get the number of HV/MV feeders that currently energize this LV feeder.
+        """
+        return nlen(self._current_energizing_feeders)
+
+    def get_current_energizing_feeder(self, mrid: str) -> Feeder:
+        """
+        Energizing feeder using the current state of the network.
+
+        @param mrid: The mrid of the `Feeder`.
+        @return A matching `Feeder` that energizes this `LvFeeder` in the current state of the network.
+        @raise A `KeyError` if no matching `Feeder` was found.
+        """
+        if not self._current_energizing_feeders:
+            raise KeyError(mrid)
+        try:
+            return self._current_energizing_feeders[mrid]
+        except AttributeError:
+            raise KeyError(mrid)
+
+    def add_current_energizing_feeder(self, feeder: Feeder) -> LvFeeder:
+        """
+        Associate this `LvFeeder` with a `Feeder` in the current state of the network.
+
+        @param feeder: the HV/MV feeder to associate with this LV feeder in the current state of the network.
+        @return: This `LvFeeder` for fluent use.
+        """
+        if self._validate_reference(feeder, self.get_current_energizing_feeder, "A Feeder"):
+            return self
+        self._current_energizing_feeders = dict() if self._current_energizing_feeders is None else self._current_energizing_feeders
+        self._current_energizing_feeders[feeder.mrid] = feeder
+        return self
+
+    def remove_current_energizing_feeder(self, feeder: Feeder) -> LvFeeder:
+        """
+        Disassociate this `LvFeeder` from a `Feeder` in the current state of the network.
+
+        @param feeder: the HV/MV feeder to disassociate from this LV feeder in the current state of the network.
+        @return: This `LvFeeder` for fluent use.
+        @raise: A `ValueError` if `feeder` is not found in the current energizing feeders collection.
+        """
+        self._current_energizing_feeders = safe_remove_by_id(self._current_energizing_feeders, feeder)
+        return self
+
+    def clear_current_energizing_feeders(self) -> LvFeeder:
+        """
+        Clear all `Feeder`s associated with `LvFeeder` in the current state of the network.
+
+        @return: This `LvFeeder` for fluent use.
+        """
+        self._current_energizing_feeders = None
         return self
 
     @property

--- a/src/zepben/evolve/model/cim/iec61970/infiec61970/feeder/lv_feeder.py
+++ b/src/zepben/evolve/model/cim/iec61970/infiec61970/feeder/lv_feeder.py
@@ -55,7 +55,6 @@ class LvFeeder(EquipmentContainer):
             for feeder in current_energizing_feeders:
                 self.add_current_energizing_feeder(feeder)
 
-
     @property
     def normal_head_terminal(self) -> Optional[Terminal]:
         """

--- a/src/zepben/evolve/services/common/reference_resolvers.py
+++ b/src/zepben/evolve/services/common/reference_resolvers.py
@@ -99,7 +99,7 @@ __all__ = [
     "prf_to_relay_info_resolver", "rc_to_rce_resolver", "rce_to_rc_resolver", "rc_to_term_resolver", "tc_to_tcc_resolver", "prf_to_psw_resolver",
     "psw_to_prf_resolver", "prf_to_sen_resolver", "sen_to_prf_resolver", "prf_to_prscheme_resolver", "prscheme_to_prf_resolver",
     "prscheme_to_prsystem_resolver", "battery_unit_to_battery_control_resolver", "ed_to_edf_resolver",
-    "prsystem_to_prscheme_resolver", "fuse_to_prf_resolver", "sm_to_rcc_resolver"]
+    "prsystem_to_prscheme_resolver", "fuse_to_prf_resolver", "sm_to_rcc_resolver", "feeder_to_celvf_resolver", "lvfeeder_to_cef_resolver"]
 
 
 @dataclass(frozen=True, eq=False, slots=True)
@@ -249,6 +249,7 @@ ec_to_curequipment_resolver = ReferenceResolver(EquipmentContainer, Equipment, l
 feeder_to_nes_resolver = ReferenceResolver(Feeder, Substation, lambda t, r: setattr(t, 'normal_energizing_substation', r))
 feeder_to_nht_resolver = ReferenceResolver(Feeder, Terminal, lambda t, r: setattr(t, 'normal_head_terminal', r))
 feeder_to_nelvf_resolver = ReferenceResolver(Feeder, LvFeeder, lambda t, r: t.add_normal_energized_lv_feeder(r))
+feeder_to_celvf_resolver = ReferenceResolver(Feeder, LvFeeder, lambda t, r: t.add_current_energized_lv_feeder(r))
 
 gr_to_sgr_resolver = ReferenceResolver(GeographicalRegion, SubGeographicalRegion, lambda t, r: t.add_sub_geographical_region(r))
 
@@ -301,6 +302,7 @@ loop_to_esub_resolver = ReferenceResolver(Loop, Substation, lambda t, r: t.add_e
 
 lvfeeder_to_nht_resolver = ReferenceResolver(LvFeeder, Terminal, lambda t, r: setattr(t, 'normal_head_terminal', r))
 lvfeeder_to_nef_resolver = ReferenceResolver(LvFeeder, Feeder, lambda t, r: t.add_normal_energizing_feeder(r))
+lvfeeder_to_cef_resolver = ReferenceResolver(LvFeeder, Feeder, lambda t, r: t.add_current_energizing_feeder(r))
 
 pec_to_pecphase_resolver = ReferenceResolver(PowerElectronicsConnection, PowerElectronicsConnectionPhase, lambda t, r: t.add_phase(r))
 pecphase_to_pec_resolver = ReferenceResolver(PowerElectronicsConnectionPhase,

--- a/src/zepben/evolve/services/common/resolver.py
+++ b/src/zepben/evolve/services/common/resolver.py
@@ -257,10 +257,18 @@ def normal_energized_lv_feeders(feeder: Feeder) -> BoundReferenceResolver:
     # noinspection PyArgumentList
     return BoundReferenceResolver(feeder, feeder_to_nelvf_resolver, lvfeeder_to_nef_resolver)
 
+def current_energized_lv_feeders(feeder: Feeder) -> BoundReferenceResolver:
+    # noinspection PyArgumentList
+    return BoundReferenceResolver(feeder, feeder_to_celvf_resolver, lvfeeder_to_cef_resolver)
+
 
 def normal_energizing_feeders(lv_feeder: LvFeeder) -> BoundReferenceResolver:
     # noinspection PyArgumentList
     return BoundReferenceResolver(lv_feeder, lvfeeder_to_nef_resolver, feeder_to_nelvf_resolver)
+
+def current_energizing_feeders(lv_feeder: LvFeeder) -> BoundReferenceResolver:
+    # noinspection PyArgumentList
+    return BoundReferenceResolver(lv_feeder, lvfeeder_to_cef_resolver, feeder_to_celvf_resolver)
 
 
 def normal_energizing_substation(feeder: Feeder) -> BoundReferenceResolver:

--- a/src/zepben/evolve/services/common/resolver.py
+++ b/src/zepben/evolve/services/common/resolver.py
@@ -257,6 +257,7 @@ def normal_energized_lv_feeders(feeder: Feeder) -> BoundReferenceResolver:
     # noinspection PyArgumentList
     return BoundReferenceResolver(feeder, feeder_to_nelvf_resolver, lvfeeder_to_nef_resolver)
 
+
 def current_energized_lv_feeders(feeder: Feeder) -> BoundReferenceResolver:
     # noinspection PyArgumentList
     return BoundReferenceResolver(feeder, feeder_to_celvf_resolver, lvfeeder_to_cef_resolver)
@@ -265,6 +266,7 @@ def current_energized_lv_feeders(feeder: Feeder) -> BoundReferenceResolver:
 def normal_energizing_feeders(lv_feeder: LvFeeder) -> BoundReferenceResolver:
     # noinspection PyArgumentList
     return BoundReferenceResolver(lv_feeder, lvfeeder_to_nef_resolver, feeder_to_nelvf_resolver)
+
 
 def current_energizing_feeders(lv_feeder: LvFeeder) -> BoundReferenceResolver:
     # noinspection PyArgumentList

--- a/src/zepben/evolve/services/network/network_service_comparator.py
+++ b/src/zepben/evolve/services/network/network_service_comparator.py
@@ -527,6 +527,7 @@ class NetworkServiceComparator(BaseServiceComparator):
         self._compare_id_reference_collections(diff, Feeder.normal_energized_lv_feeders)
         if self._options.compare_feeder_equipment:
             self._compare_id_reference_collections(diff, Feeder.current_equipment)
+        self._compare_id_reference_collections(diff, Feeder.current_energized_lv_feeders)
 
         return self._compare_equipment_container(diff)
 
@@ -1234,6 +1235,7 @@ class NetworkServiceComparator(BaseServiceComparator):
         self._compare_id_reference_collections(diff, LvFeeder.normal_energizing_feeders)
         if self._options.compare_feeder_equipment:
             self._compare_id_reference_collections(diff, LvFeeder.current_equipment)
+        self._compare_id_reference_collections(diff, LvFeeder.current_energizing_feeders)
 
         return self._compare_equipment_container(diff)
 

--- a/src/zepben/evolve/services/network/translator/network_cim2proto.py
+++ b/src/zepben/evolve/services/network/translator/network_cim2proto.py
@@ -1684,7 +1684,7 @@ def lv_feeder_to_pb(cim: LvFeeder) -> PBLvFeeder:
         ec=equipment_container_to_pb(cim),
         normalHeadTerminalMRID=mrid_or_empty(cim.normal_head_terminal),
         normalEnergizingFeederMRIDs=[str(io.mrid) for io in cim.normal_energizing_feeders],
-        currentlyEnergizingFeedersMRIDs=[str(io.mrid) for io in cim.current_energizing_feeders]
+        currentlyEnergizingFeederMRIDs=[str(io.mrid) for io in cim.current_energizing_feeders]
     )
 
 

--- a/src/zepben/evolve/services/network/translator/network_cim2proto.py
+++ b/src/zepben/evolve/services/network/translator/network_cim2proto.py
@@ -810,7 +810,8 @@ def feeder_to_pb(cim: Feeder) -> PBFeeder:
         ec=equipment_container_to_pb(cim),
         normalHeadTerminalMRID=mrid_or_empty(cim.normal_head_terminal),
         normalEnergizingSubstationMRID=mrid_or_empty(cim.normal_energizing_substation),
-        normalEnergizedLvFeederMRIDs=[str(io.mrid) for io in cim.normal_energized_lv_feeders]
+        normalEnergizedLvFeederMRIDs=[str(io.mrid) for io in cim.normal_energized_lv_feeders],
+        currentlyEnergizedLvFeedersMRIDs=[str(io.mrid) for io in cim.current_energized_lv_feeders]
     )
 
 
@@ -1682,7 +1683,8 @@ def lv_feeder_to_pb(cim: LvFeeder) -> PBLvFeeder:
     return PBLvFeeder(
         ec=equipment_container_to_pb(cim),
         normalHeadTerminalMRID=mrid_or_empty(cim.normal_head_terminal),
-        normalEnergizingFeederMRIDs=[str(io.mrid) for io in cim.normal_energizing_feeders]
+        normalEnergizingFeederMRIDs=[str(io.mrid) for io in cim.normal_energizing_feeders],
+        currentlyEnergizingFeedersMRIDs=[str(io.mrid) for io in cim.current_energizing_feeders]
     )
 
 

--- a/src/zepben/evolve/services/network/translator/network_proto2cim.py
+++ b/src/zepben/evolve/services/network/translator/network_proto2cim.py
@@ -899,6 +899,8 @@ def feeder_to_cim(pb: PBFeeder, network_service: NetworkService) -> Optional[Fee
     network_service.resolve_or_defer_reference(resolver.normal_energizing_substation(cim), pb.normalEnergizingSubstationMRID)
     for mrid in pb.normalEnergizedLvFeederMRIDs:
         network_service.resolve_or_defer_reference(resolver.normal_energized_lv_feeders(cim), mrid)
+    for mrid in pb.currentlyEnergizedLvFeedersMRIDs:
+        network_service.resolve_or_defer_reference(resolver.current_energized_lv_feeders(cim), mrid)
 
     equipment_container_to_cim(pb.ec, cim, network_service)
     return cim if network_service.add(cim) else None
@@ -1968,6 +1970,8 @@ def lv_feeder_to_cim(pb: PBLvFeeder, network_service: NetworkService) -> Optiona
     network_service.resolve_or_defer_reference(resolver.lv_feeder_normal_head_terminal(cim), pb.normalHeadTerminalMRID)
     for mrid in pb.normalEnergizingFeederMRIDs:
         network_service.resolve_or_defer_reference(resolver.normal_energizing_feeders(cim), mrid)
+    for mrid in pb.currentlyEnergizingFeedersMRIDs:
+        network_service.resolve_or_defer_reference(resolver.current_energizing_feeders(cim), mrid)
 
     equipment_container_to_cim(pb.ec, cim, network_service)
     return cim if network_service.add(cim) else None

--- a/src/zepben/evolve/services/network/translator/network_proto2cim.py
+++ b/src/zepben/evolve/services/network/translator/network_proto2cim.py
@@ -1970,7 +1970,7 @@ def lv_feeder_to_cim(pb: PBLvFeeder, network_service: NetworkService) -> Optiona
     network_service.resolve_or_defer_reference(resolver.lv_feeder_normal_head_terminal(cim), pb.normalHeadTerminalMRID)
     for mrid in pb.normalEnergizingFeederMRIDs:
         network_service.resolve_or_defer_reference(resolver.normal_energizing_feeders(cim), mrid)
-    for mrid in pb.currentlyEnergizingFeedersMRIDs:
+    for mrid in pb.currentlyEnergizingFeederMRIDs:
         network_service.resolve_or_defer_reference(resolver.current_energizing_feeders(cim), mrid)
 
     equipment_container_to_cim(pb.ec, cim, network_service)

--- a/test/cim/cim_creators.py
+++ b/test/cim/cim_creators.py
@@ -644,7 +644,8 @@ def create_equipment_container(include_runtime: bool, add_equipment: bool = True
 def create_feeder(include_runtime: bool = True):
     runtime = {
         "normal_energized_lv_feeders": lists(builds(LvFeeder, **create_identified_object(include_runtime)), min_size=1, max_size=2),
-        "current_equipment": lists(sampled_equipment(include_runtime), min_size=1, max_size=2)
+        "current_equipment": lists(sampled_equipment(include_runtime), min_size=1, max_size=2),
+        "current_energized_lv_feeders": lists(builds(LvFeeder, **create_identified_object(include_runtime)), min_size=1, max_size=2),
     } if include_runtime else {}
 
     return builds(
@@ -1601,7 +1602,8 @@ def create_loop(include_runtime: bool = True):
 def create_lv_feeder(include_runtime: bool = True):
     runtime = {
         "normal_energizing_feeders": lists(builds(Feeder, **create_identified_object(include_runtime)), min_size=1, max_size=2),
-        "current_equipment": lists(sampled_equipment(include_runtime), min_size=1, max_size=2)
+        "current_equipment": lists(sampled_equipment(include_runtime), min_size=1, max_size=2),
+        "current_energizing_feeders": lists(builds(Feeder, **create_identified_object(include_runtime)), min_size=1, max_size=2)
     } if include_runtime else {}
 
     return builds(

--- a/test/cim/iec61970/base/core/test_feeder.py
+++ b/test/cim/iec61970/base/core/test_feeder.py
@@ -92,6 +92,7 @@ def test_normal_energized_lv_feeder_collection():
         Feeder.clear_normal_energized_lv_feeders
     )
 
+
 def test_current_energized_lv_feeder_collection():
     validate_unordered_1234567890(
         Feeder,

--- a/test/cim/iec61970/base/core/test_feeder.py
+++ b/test/cim/iec61970/base/core/test_feeder.py
@@ -16,10 +16,11 @@ feeder_kwargs = {
     "normal_head_terminal": builds(Terminal),
     "normal_energizing_substation": builds(Substation),
     "normal_energized_lv_feeders": lists(builds(LvFeeder), max_size=2),
-    "current_equipment": lists(builds(Equipment), max_size=2)
+    "current_equipment": lists(builds(Equipment), max_size=2),
+    "current_energized_lv_feeders": lists(builds(LvFeeder), max_size=2)
 }
 
-feeder_args = [*equipment_container_args, Terminal(), Substation(), {"lvf": LvFeeder()}, {"ce": Equipment()}]
+feeder_args = [*equipment_container_args, Terminal(), Substation(), {"lvf": LvFeeder()}, {"ce": Equipment()}, {"celvf": Equipment()}]
 
 
 def test_feeder_constructor_default():
@@ -28,21 +29,26 @@ def test_feeder_constructor_default():
     verify_equipment_container_constructor_default(f)
     assert not f.normal_head_terminal
     assert not f.normal_energizing_substation
+    assert not list(f.normal_energized_lv_feeders)
     assert not list(f.current_equipment)
+    assert not list(f.current_energized_lv_feeders)
 
 
 @given(**feeder_kwargs)
-def test_feeder_constructor_kwargs(normal_head_terminal, normal_energizing_substation, normal_energized_lv_feeders, current_equipment, **kwargs):
+def test_feeder_constructor_kwargs(normal_head_terminal, normal_energizing_substation, normal_energized_lv_feeders, current_equipment, current_energized_lv_feeders, **kwargs):
     f = Feeder(normal_head_terminal=normal_head_terminal,
                normal_energizing_substation=normal_energizing_substation,
                normal_energized_lv_feeders=normal_energized_lv_feeders,
                current_equipment=current_equipment,
+               current_energized_lv_feeders=current_energized_lv_feeders,
                **kwargs)
 
     verify_equipment_container_constructor_kwargs(f, **kwargs)
     assert f.normal_head_terminal == normal_head_terminal
     assert f.normal_energizing_substation == normal_energizing_substation
+    assert list(f.normal_energized_lv_feeders) == normal_energized_lv_feeders
     assert list(f.current_equipment) == current_equipment
+    assert list(f.current_energized_lv_feeders) == current_energized_lv_feeders
 
 
 def test_feeder_constructor_args():
@@ -50,14 +56,15 @@ def test_feeder_constructor_args():
 
     verify_equipment_container_constructor_args(f)
 
-    assert feeder_args[-4:-2] == [
+    assert feeder_args[-5:-3] == [
         f.normal_head_terminal,
         f.normal_energizing_substation
     ]
     # We use a different style of matching here as the passed in args for current_equipment and normal_energized_lv_feeders
     # are maps and the stored collections are lists.
-    assert list(f.current_equipment) == list(feeder_args[-2].values())
-    assert list(f.normal_energized_lv_feeders) == list(feeder_args[-1].values())
+    assert list(f.current_equipment) == list(feeder_args[-3].values())
+    assert list(f.normal_energized_lv_feeders) == list(feeder_args[-2].values())
+    assert list(f.current_energized_lv_feeders) == list(feeder_args[-1].values())
 
 
 def test_current_equipment_collection():
@@ -83,6 +90,18 @@ def test_normal_energized_lv_feeder_collection():
         Feeder.add_normal_energized_lv_feeder,
         Feeder.remove_normal_energized_lv_feeder,
         Feeder.clear_normal_energized_lv_feeders
+    )
+
+def test_current_energized_lv_feeder_collection():
+    validate_unordered_1234567890(
+        Feeder,
+        lambda mrid: LvFeeder(mrid),
+        Feeder.current_energized_lv_feeders,
+        Feeder.num_current_energized_lv_feeders,
+        Feeder.get_current_energized_lv_feeder,
+        Feeder.add_current_energized_lv_feeder,
+        Feeder.remove_current_energized_lv_feeder,
+        Feeder.clear_current_energized_lv_feeders
     )
 
 

--- a/test/cim/iec61970/infiec61970/feeder/test_lv_feeder.py
+++ b/test/cim/iec61970/infiec61970/feeder/test_lv_feeder.py
@@ -14,10 +14,11 @@ lv_feeder_kwargs = {
     **equipment_container_kwargs,
     "normal_head_terminal": builds(Terminal),
     "normal_energizing_feeders": lists(builds(Feeder), max_size=2),
-    "current_equipment": lists(builds(Equipment), max_size=2)
+    "current_equipment": lists(builds(Equipment), max_size=2),
+    "current_energizing_feeders": lists(builds(Feeder), max_size=2)
 }
 
-lv_feeder_args = [*equipment_container_args, Terminal(), {"f": Feeder()}, {"ce": Equipment()}]
+lv_feeder_args = [*equipment_container_args, Terminal(), {"f": Feeder()}, {"ce": Equipment()}, {"cef": Feeder()}]
 
 
 def test_lv_feeder_constructor_default():
@@ -27,14 +28,16 @@ def test_lv_feeder_constructor_default():
     assert not lvf.normal_head_terminal
     assert not list(lvf.normal_energizing_feeders)
     assert not list(lvf.current_equipment)
+    assert not list(lvf.current_energizing_feeders)
 
 
 @given(**lv_feeder_kwargs)
-def test_lv_feeder_constructor_kwargs(normal_head_terminal, normal_energizing_feeders, current_equipment, **kwargs):
+def test_lv_feeder_constructor_kwargs(normal_head_terminal, normal_energizing_feeders, current_equipment, current_energizing_feeders, **kwargs):
     lvf = LvFeeder(
         normal_head_terminal=normal_head_terminal,
         normal_energizing_feeders=normal_energizing_feeders,
         current_equipment=current_equipment,
+        current_energizing_feeders=current_energizing_feeders,
         **kwargs
     )
 
@@ -42,19 +45,21 @@ def test_lv_feeder_constructor_kwargs(normal_head_terminal, normal_energizing_fe
     assert lvf.normal_head_terminal == normal_head_terminal
     assert list(lvf.normal_energizing_feeders) == normal_energizing_feeders
     assert list(lvf.current_equipment) == current_equipment
+    assert list(lvf.current_energizing_feeders) == current_energizing_feeders
 
 
 def test_lv_feeder_constructor_args():
     lvf = LvFeeder(*lv_feeder_args)
 
     verify_equipment_container_constructor_args(lvf)
-    assert lv_feeder_args[-3:-2] == [
+    assert lv_feeder_args[-4:-3] == [
         lvf.normal_head_terminal
     ]
     # We use a different style of matching here as the passed in args for normal_energizing_feeders and current_equipment
     # are maps and the stored collections are lists.
-    assert list(lvf.normal_energizing_feeders) == list(lv_feeder_args[-2].values())
-    assert list(lvf.current_equipment) == list(lv_feeder_args[-1].values())
+    assert list(lvf.normal_energizing_feeders) == list(lv_feeder_args[-3].values())
+    assert list(lvf.current_equipment) == list(lv_feeder_args[-2].values())
+    assert list(lvf.current_energizing_feeders) == list(lv_feeder_args[-1].values())
 
 
 def test_current_equipment_collection():
@@ -80,4 +85,16 @@ def test_normal_energizing_feeder_collection():
         LvFeeder.add_normal_energizing_feeder,
         LvFeeder.remove_normal_energizing_feeder,
         LvFeeder.clear_normal_energizing_feeders
+    )
+
+def test_current_energizing_feeder_collection():
+    validate_unordered_1234567890(
+        LvFeeder,
+        lambda mrid: Feeder(mrid),
+        LvFeeder.current_energizing_feeders,
+        LvFeeder.num_current_energizing_feeders,
+        LvFeeder.get_current_energizing_feeder,
+        LvFeeder.add_current_energizing_feeder,
+        LvFeeder.remove_current_energizing_feeder,
+        LvFeeder.clear_current_energizing_feeders
     )

--- a/test/cim/iec61970/infiec61970/feeder/test_lv_feeder.py
+++ b/test/cim/iec61970/infiec61970/feeder/test_lv_feeder.py
@@ -87,6 +87,7 @@ def test_normal_energizing_feeder_collection():
         LvFeeder.clear_normal_energizing_feeders
     )
 
+
 def test_current_energizing_feeder_collection():
     validate_unordered_1234567890(
         LvFeeder,

--- a/test/services/network/test_network_service_comparator.py
+++ b/test/services/network/test_network_service_comparator.py
@@ -550,6 +550,13 @@ class TestNetworkServiceComparator(TestBaseServiceComparator):
             lambda _: LvFeeder(mrid="lvf1"),
             lambda _: LvFeeder(mrid="lvf2")
         )
+        self.validator.validate_collection(
+            Feeder.current_energized_lv_feeders,
+            Feeder.add_current_energized_lv_feeder,
+            Feeder,
+            lambda _: LvFeeder(mrid="lvf1"),
+            lambda _: LvFeeder(mrid="lvf2")
+        )
 
     def test_compare_geographical_region(self):
         self._compare_identified_object(GeographicalRegion)
@@ -1426,6 +1433,13 @@ class TestNetworkServiceComparator(TestBaseServiceComparator):
         self.validator.validate_collection(
             LvFeeder.normal_energizing_feeders,
             LvFeeder.add_normal_energizing_feeder,
+            LvFeeder,
+            lambda _: Feeder(mrid="f1"),
+            lambda _: Feeder(mrid="f2")
+        )
+        self.validator.validate_collection(
+            LvFeeder.current_energizing_feeders,
+            LvFeeder.add_current_energizing_feeder,
             LvFeeder,
             lambda _: Feeder(mrid="f1"),
             lambda _: Feeder(mrid="f2")


### PR DESCRIPTION
# Description

Pulled in current state container enhancement from `ewb-grpc`. Modified NetworkConsumerClient to support the rpc changes. Also, Feeder and LvFeeder CIM model have been added with their current network state association.

~This PR can be reviewed but will fail to build until this [task](https://app.clickup.com/t/6929263/DEV-2041) has been merged and this branch rebased. This [PR](https://github.com/zepben/ewb-grpc/pull/121) will also need to be merged in and the `zepben.protobuf` version updated.~

# Associated tasks

- ~https://github.com/zepben/ewb-grpc/pull/121~
- ~https://github.com/zepben/ewb-sdk-python/pull/165 (for https://app.clickup.com/t/6929263/DEV-2041)~
- https://github.com/zepben/ewb-sdk-python/pull/162

# Test Steps

None.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- ~[ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

GRPC's NetworkConsumerService introduced breaking changes and it is applied to the NetworkConsumerClient.
