### PR TITLE
[DEV-2041] Additional current state status processing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,20 @@
 # Zepben Python SDK
 ## [0.43.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* Renamed `UpdateNetworkStateClient.SetCurrentStatesRequest` to `CurrentStateEventBatch`. You will need to update any uses, but the class members are the same.
+* Removed `ProcessingPaused` current state response message as this functionality won't be supported.
+* `QueryNetworkStateClient.get_current_states` now returns a `CurrentStateEventBatch` rather than just the events themselves.
+* `QueryNetworkStateService.on_get_current_states` must now return a stream of `CurrentStateEventBatch` rather than just the events themselves.
 
 ### New Features
-* None.
+* Added `BatchNotProcessed` current state response. This is used to indicate a batch has been ignored, rather than just returning a `BatchSuccessful`.
+* `QueryNetworkStateService` now supports `reportBatchStatus`, which requires two new constructor callbacks:
+  * `on_current_states_status` - A callback triggered when the response status of an event returned via `on_get_current_states` is received from the client.
+  * `on_processing_error` - A function that takes a message and optional cause. Called when `on_current_states_status` raises an exception, or the
+    `SetCurrentStatesResponse` is for an unknown event status.
 
 ### Enhancements
-* None.
+* All `StateEventFailure` classes now have a `message` included to give more context to the error.
 
 ### Fixes
 * None.

--- a/docs/docs/query-network-state-client.mdx
+++ b/docs/docs/query-network-state-client.mdx
@@ -15,7 +15,7 @@ wrapper for the gRPC library, with the ability to retrieve information about the
 
 ## Creating a gRPC channel
 
-The channel gRPC channel can be directly from the gPRC libray, or using our `GrpcChannelBuilder` helper. At its most basic, this can be achieved with:
+The channel gRPC channel can be directly from the gRPC library, or using our `GrpcChannelBuilder` helper. At its most basic, this can be achieved with:
 
 ```python
 from zepben.evolve import GrpcChannelBuilder

--- a/docs/docs/update-network-state-client.mdx
+++ b/docs/docs/update-network-state-client.mdx
@@ -15,7 +15,7 @@ wrapper for the gRPC library, with the ability to update information about the s
 
 ## Creating a gRPC channel
 
-The channel gRPC channel can be directly from the gPRC libray, or using our `GrpcChannelBuilder` helper. At its most basic, this can be achieved with:
+The channel gRPC channel can be directly from the gRPC library, or using our `GrpcChannelBuilder` helper. At its most basic, this can be achieved with:
 
 ```python
 from zepben.evolve import GrpcChannelBuilder

--- a/docs/versioned_docs/version-0.42.0/query-network-state-client.mdx
+++ b/docs/versioned_docs/version-0.42.0/query-network-state-client.mdx
@@ -15,7 +15,7 @@ wrapper for the gRPC library, with the ability to retrieve information about the
 
 ## Creating a gRPC channel
 
-The channel gRPC channel can be directly from the gPRC libray, or using our `GrpcChannelBuilder` helper. At its most basic, this can be achieved with:
+The channel gRPC channel can be directly from the gRPC library, or using our `GrpcChannelBuilder` helper. At its most basic, this can be achieved with:
 
 ```python
 from zepben.evolve import GrpcChannelBuilder

--- a/docs/versioned_docs/version-0.42.0/update-network-state-client.mdx
+++ b/docs/versioned_docs/version-0.42.0/update-network-state-client.mdx
@@ -15,7 +15,7 @@ wrapper for the gRPC library, with the ability to update information about the s
 
 ## Creating a gRPC channel
 
-The channel gRPC channel can be directly from the gPRC libray, or using our `GrpcChannelBuilder` helper. At its most basic, this can be achieved with:
+The channel gRPC channel can be directly from the gRPC library, or using our `GrpcChannelBuilder` helper. At its most basic, this can be achieved with:
 
 ```python
 from zepben.evolve import GrpcChannelBuilder
@@ -85,8 +85,6 @@ async for response in client.set_current_states_in_batches(events_in_batches()):
 Each batch will receive its own response, which will be one of the following:
 * `BatchSuccessful` - Indicates that all events in the batch were processed successfully. Events that are ignored because they set the state to one that is
   already present, or are skipped due to a later event applying the opposite action, will be marked as successful.
-* `ProcessingPaused` - Indicates the entire batch was ignore as current state processing in teh server is currently paused. The response will include the time
-  the server was paused.
 * `BatchFailure` - Indicates at least one event in the batch could not be applied. Each event that failed will indicate why it failed, some of which will have
   more impact than others.
   * `StateEventUnknownMrid` - The `mRID` of the event could not be found in the network hosted by this server.
@@ -95,6 +93,10 @@ Each batch will receive its own response, which will be one of the following:
     `mRID` that belongs to a `Cut`.
   * `StateEventUnsupportedPhasing` - You tried to specify phases that do not make sense to the item being updated. When using the default phasing of `NONE` you
     will never receive this error. Until un-ganged switching is supported, this error will be returned for all events that specify phases.
+  * `StateEventUnsupportedMrid` - The `mRID` provided can't be used to perform the given action even though it is of the correct type. e.g. Trying to open/close
+   a switch in a voltage level that hasn't been implemented in the server.
+
+* `BatchNotProcessed` - Indicates the entire batch was ignored because the message ID of the batch was prior to the last processed batch.
 
 You can check the type of response or failure by checking against the types above.
 ```python

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 deps = [
     "zepben.auth==0.12.1",
-    "zepben.protobuf==0.32.0",
+    "zepben.protobuf==0.33.0b2",
     "dataclassy==0.6.2",
     "six==1.16.0"
 ]

--- a/src/zepben/evolve/__init__.py
+++ b/src/zepben/evolve/__init__.py
@@ -214,6 +214,7 @@ from zepben.evolve.streaming.grpc.grpc import *
 from zepben.evolve.streaming.grpc.grpc_channel_builder import *
 from zepben.evolve.streaming.grpc.connect import *
 from zepben.evolve.streaming.data.current_state_event import *
+from zepben.evolve.streaming.data.current_state_event_batch import *
 from zepben.evolve.streaming.data.set_current_states_status import *
 from zepben.evolve.streaming.get.query_network_state_service import *
 from zepben.evolve.streaming.get.query_network_state_client import *

--- a/src/zepben/evolve/streaming/data/current_state_event_batch.py
+++ b/src/zepben/evolve/streaming/data/current_state_event_batch.py
@@ -1,0 +1,24 @@
+#  Copyright 2024 Zeppelin Bend Pty Ltd
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+__all__ = ["CurrentStateEventBatch"]
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from zepben.evolve.streaming.data.current_state_event import CurrentStateEvent
+
+
+@dataclass
+class CurrentStateEventBatch:
+    """
+    A collection of events that should be operated on as a batch.
+
+    Attributes:
+        batch_id: A unique identifier for the batch of events being processed. This allows tracking or grouping multiple events under a single batch.
+        events: A list of `CurrentStateEvent` objects representing the state changes or events that are being submitted in the current batch.
+    """
+
+    batch_id: int
+    events: Iterable[CurrentStateEvent]

--- a/src/zepben/evolve/streaming/data/set_current_states_status.py
+++ b/src/zepben/evolve/streaming/data/set_current_states_status.py
@@ -2,21 +2,18 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
-__all__ = ["SetCurrentStatesStatus", "BatchSuccessful", "ProcessingPaused", "BatchFailure", "StateEventFailure", "StateEventInvalidMrid",
-           "StateEventUnknownMrid", "StateEventDuplicateMrid", "StateEventUnsupportedPhasing"]
+__all__ = ["SetCurrentStatesStatus", "BatchSuccessful", "BatchFailure", "BatchNotProcessed", "StateEventFailure", "StateEventInvalidMrid",
+           "StateEventUnknownMrid", "StateEventDuplicateMrid", "StateEventUnsupportedPhasing", "StateEventUnsupportedMrid"]
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import datetime
 from typing import List, Optional, Tuple
 
-from zepben.protobuf.ns.data.change_status_pb2 import BatchSuccessful as PBBatchSuccessful, ProcessingPaused as PBProcessingPaused, \
-    BatchFailure as PBBatchFailure, StateEventFailure as PBStateEventFailure, StateEventUnknownMrid as PBStateEventUnknownMrid, \
+from zepben.protobuf.ns.data.change_status_pb2 import BatchSuccessful as PBBatchSuccessful, BatchFailure as PBBatchFailure, \
+    BatchNotProcessed as PBBatchNotProcessed, StateEventFailure as PBStateEventFailure, StateEventUnknownMrid as PBStateEventUnknownMrid, \
     StateEventDuplicateMrid as PBStateEventDuplicateMrid, StateEventInvalidMrid as PBStateEventInvalidMrid, \
-    StateEventUnsupportedPhasing as PBStateEventUnsupportedPhasing
+    StateEventUnsupportedPhasing as PBStateEventUnsupportedPhasing, StateEventUnsupportedMrid as PBStateEventUnsupportedMrid
 from zepben.protobuf.ns.network_state_responses_pb2 import SetCurrentStatesResponse as PBSetCurrentStatesResponse
-
-from zepben.evolve.util import datetime_to_timestamp
 
 
 class SetCurrentStatesStatus(ABC):
@@ -39,10 +36,10 @@ class SetCurrentStatesStatus(ABC):
         status = pb.WhichOneof("status")
         if status == "success":
             return BatchSuccessful.from_pb(pb)
-        elif status == "paused":
-            return ProcessingPaused.from_pb(pb)
         elif status == "failure":
             return BatchFailure.from_pb(pb)
+        elif status == "notProcessed":
+            return BatchNotProcessed.from_pb(pb)
 
     @abstractmethod
     def to_pb(self) -> PBSetCurrentStatesResponse:
@@ -77,36 +74,6 @@ class BatchSuccessful(SetCurrentStatesStatus):
         Creates a protobuf SetCurrentStatesResponse object with success.
         """
         return PBSetCurrentStatesResponse(messageId=self.batch_id, success=PBBatchSuccessful())
-
-
-@dataclass
-class ProcessingPaused(SetCurrentStatesStatus):
-    """
-    A response indicating that current state events are not currently being processed. There is no need to retry these,
-    the missed events will be requested when processing resumes.
-
-    Attributes:
-        batch_id: The unique identifier of the batch that was processed. This matches the
-                  batch ID from the original request to allow correlation between request and response.
-        since: The timestamp when the processing was paused.
-    """
-
-    def __init__(self, batch_id: int, since: datetime):
-        super().__init__(batch_id)
-        self.since = since
-
-    @staticmethod
-    def from_pb(pb: PBSetCurrentStatesResponse) -> 'ProcessingPaused':
-        """
-        Creates a ProcessingPaused object from a protobuf SetCurrentStatesResponse.
-        """
-        return ProcessingPaused(batch_id=pb.messageId, since=pb.paused.since.ToDatetime())
-
-    def to_pb(self) -> PBSetCurrentStatesResponse:
-        """
-        Creates a protobuf SetCurrentStatesResponse object with paused.
-        """
-        return PBSetCurrentStatesResponse(messageId=self.batch_id, paused=PBProcessingPaused(since=datetime_to_timestamp(self.since)))
 
 
 @dataclass
@@ -147,16 +114,47 @@ class BatchFailure(SetCurrentStatesStatus):
                                           failure=PBBatchFailure(partialFailure=self.partial_failure, failed=[fail.to_pb() for fail in self.failures]))
 
 
+@dataclass
+class BatchNotProcessed(SetCurrentStatesStatus):
+    """
+    A response indicating all items in the batch were ignored because the message ID of the batch was prior to the
+    last processed batch. This is expected when starting the service if the same item is sent to the current state
+    processing queue and is also included in the backlog processing response.
+
+    Attributes:
+        batch_id: The unique identifier of the batch that was processed. This matches the
+                  batch ID from the original request to allow correlation between request and response.
+    """
+
+    def __init__(self, batch_id: int):
+        super().__init__(batch_id)
+
+    @staticmethod
+    def from_pb(pb: PBSetCurrentStatesResponse) -> 'BatchNotProcessed':
+        """
+        Creates a BatchNotProcessed object from a protobuf SetCurrentStatesResponse.
+        """
+        return BatchNotProcessed(batch_id=pb.messageId)
+
+    def to_pb(self) -> PBSetCurrentStatesResponse:
+        """
+        Creates a protobuf SetCurrentStatesResponse object with notProcessed.
+        """
+        return PBSetCurrentStatesResponse(messageId=self.batch_id, notProcessed=PBBatchNotProcessed())
+
+
 class StateEventFailure(ABC):
     """
     A wrapper class for allowing a one-of to be repeated.
 
     Attributes:
         event_id: The event ID of the state event that failed.
+        message: A message describing why the event failed.
     """
 
-    def __init__(self, event_id: str):
+    def __init__(self, event_id: str, message: str):
         self.event_id = event_id
+        self.message = message
 
     @staticmethod
     def from_pb(pb: PBStateEventFailure) -> Optional['StateEventFailure']:
@@ -172,13 +170,15 @@ class StateEventFailure(ABC):
             return StateEventInvalidMrid.from_pb(pb)
         elif reason_code == "unsupportedPhasing":
             return StateEventUnsupportedPhasing.from_pb(pb)
+        elif reason_code == "unsupportedMrid":
+            return StateEventUnsupportedMrid.from_pb(pb)
         else:
             return None
 
     @abstractmethod
     def to_pb(self) -> PBStateEventFailure:
         """
-        Creates a protobuf StateEventFailure with event_id assigned along with the specified block.
+        Creates a protobuf StateEventFailure of the appropriate type.
         """
         pass
 
@@ -193,13 +193,14 @@ class StateEventUnknownMrid(StateEventFailure):
         """
         Creates a StateEventUnknownMrid object from a protobuf StateEventFailure.
         """
-        return StateEventUnknownMrid(pb.eventId)
+        return StateEventUnknownMrid(pb.eventId, pb.message)
 
     def to_pb(self) -> PBStateEventFailure:
-        """
-        Creates a protobuf StateEventFailure with event_id assigned along with the unknownMrid.
-        """
-        return PBStateEventFailure(eventId=self.event_id, unknownMrid=PBStateEventUnknownMrid())
+        return PBStateEventFailure(
+            eventId=self.event_id,
+            message=self.message,
+            unknownMrid=PBStateEventUnknownMrid()
+        )
 
 
 class StateEventDuplicateMrid(StateEventFailure):
@@ -212,13 +213,14 @@ class StateEventDuplicateMrid(StateEventFailure):
         """
         Creates a StateEventDuplicateMrid object from a protobuf StateEventFailure.
         """
-        return StateEventDuplicateMrid(pb.eventId)
+        return StateEventDuplicateMrid(pb.eventId, pb.message)
 
     def to_pb(self) -> PBStateEventFailure:
-        """
-        Creates a protobuf StateEventFailure with event_id assigned along with the duplicateMrid.
-        """
-        return PBStateEventFailure(eventId=self.event_id, duplicateMrid=PBStateEventDuplicateMrid())
+        return PBStateEventFailure(
+            eventId=self.event_id,
+            message=self.message,
+            duplicateMrid=PBStateEventDuplicateMrid()
+        )
 
 
 class StateEventInvalidMrid(StateEventFailure):
@@ -231,13 +233,14 @@ class StateEventInvalidMrid(StateEventFailure):
         """
         Creates a StateEventInvalidMrid object from a protobuf StateEventFailure.
         """
-        return StateEventInvalidMrid(pb.eventId)
+        return StateEventInvalidMrid(pb.eventId, pb.message)
 
     def to_pb(self) -> PBStateEventFailure:
-        """
-        Creates a protobuf StateEventFailure with event_id assigned along with the invalidMrid.
-        """
-        return PBStateEventFailure(eventId=self.event_id, invalidMrid=PBStateEventInvalidMrid())
+        return PBStateEventFailure(
+            eventId=self.event_id,
+            message=self.message,
+            invalidMrid=PBStateEventInvalidMrid()
+        )
 
 
 class StateEventUnsupportedPhasing(StateEventFailure):
@@ -251,10 +254,32 @@ class StateEventUnsupportedPhasing(StateEventFailure):
         """
         Creates a StateEventUnsupportedPhasing object from a protobuf StateEventFailure.
         """
-        return StateEventUnsupportedPhasing(pb.eventId)
+        return StateEventUnsupportedPhasing(pb.eventId, pb.message)
 
     def to_pb(self) -> PBStateEventFailure:
+        return PBStateEventFailure(
+            eventId=self.event_id,
+            message=self.message,
+            unsupportedPhasing=PBStateEventUnsupportedPhasing()
+        )
+
+
+class StateEventUnsupportedMrid(StateEventFailure):
+    """
+    The mRID provided can't be used to perform the given action even though it is of the correct type. e.g. Trying to
+    open/close a switch in a voltage level that hasn't been implemented in the server.
+    """
+
+    @staticmethod
+    def from_pb(pb: PBStateEventFailure) -> 'StateEventUnsupportedMrid':
         """
-        Creates a protobuf StateEventFailure with event_id assigned along with the unsupportedPhasing.
+        Creates a StateEventUnsupportedMrid object from a protobuf StateEventFailure.
         """
-        return PBStateEventFailure(eventId=self.event_id, unsupportedPhasing=PBStateEventUnsupportedPhasing())
+        return StateEventUnsupportedMrid(pb.eventId, pb.message)
+
+    def to_pb(self) -> PBStateEventFailure:
+        return PBStateEventFailure(
+            eventId=self.event_id,
+            message=self.message,
+            unsupportedMrid=PBStateEventUnsupportedMrid()
+        )

--- a/src/zepben/evolve/streaming/get/query_network_state_client.py
+++ b/src/zepben/evolve/streaming/get/query_network_state_client.py
@@ -5,14 +5,15 @@
 __all__ = ["QueryNetworkStateClient"]
 
 from datetime import datetime
-from typing import List, Callable, AsyncGenerator, Tuple
+from typing import List, Callable, AsyncGenerator
 
 from zepben.protobuf.ns.network_state_pb2_grpc import QueryNetworkStateServiceStub
 from zepben.protobuf.ns.network_state_requests_pb2 import GetCurrentStatesRequest
 
-from zepben.evolve.util import datetime_to_timestamp
 from zepben.evolve.streaming.data.current_state_event import CurrentStateEvent
+from zepben.evolve.streaming.data.current_state_event_batch import CurrentStateEventBatch
 from zepben.evolve.streaming.grpc.grpc import GrpcClient
+from zepben.evolve.util import datetime_to_timestamp
 
 
 class QueryNetworkStateClient(GrpcClient):
@@ -32,7 +33,7 @@ class QueryNetworkStateClient(GrpcClient):
         else:
             self._stub = QueryNetworkStateServiceStub(channel)
 
-    async def get_current_states(self, query_id: int, from_datetime: datetime, to_datetime: datetime) -> AsyncGenerator[Tuple[CurrentStateEvent, ...], None]:
+    async def get_current_states(self, query_id: int, from_datetime: datetime, to_datetime: datetime) -> AsyncGenerator[CurrentStateEventBatch, None]:
         """
         Asynchronously retrieves a collection containing CurrentStateEvent objects, representing the network states
         within a specified time range.
@@ -45,6 +46,10 @@ class QueryNetworkStateClient(GrpcClient):
         Returns:
             A stream of batched network state events in the specified time range.
         """
-        async for response in self._stub.getCurrentStates(
-            GetCurrentStatesRequest(messageId=query_id, fromTimestamp=datetime_to_timestamp(from_datetime), toTimestamp=datetime_to_timestamp(to_datetime))):
-            yield [CurrentStateEvent.from_pb(event) for event in response.event]
+        request = GetCurrentStatesRequest(
+            messageId=query_id,
+            fromTimestamp=datetime_to_timestamp(from_datetime),
+            toTimestamp=datetime_to_timestamp(to_datetime)
+        )
+        async for response in self._stub.getCurrentStates(request):
+            yield CurrentStateEventBatch(response.messageId, [CurrentStateEvent.from_pb(event) for event in response.event])

--- a/src/zepben/evolve/streaming/get/query_network_state_service.py
+++ b/src/zepben/evolve/streaming/get/query_network_state_service.py
@@ -5,13 +5,15 @@
 __all__ = ["QueryNetworkStateService"]
 
 from datetime import datetime
-from typing import Callable, AsyncGenerator, Iterable
+from typing import Callable, AsyncGenerator, Optional
 
+from google.protobuf import empty_pb2
 from zepben.protobuf.ns.network_state_pb2_grpc import QueryNetworkStateServiceServicer
 from zepben.protobuf.ns.network_state_requests_pb2 import GetCurrentStatesRequest
-from zepben.protobuf.ns.network_state_responses_pb2 import GetCurrentStatesResponse
+from zepben.protobuf.ns.network_state_responses_pb2 import GetCurrentStatesResponse, SetCurrentStatesResponse
 
-from zepben.evolve.streaming.data.current_state_event import CurrentStateEvent
+from zepben.evolve.streaming.data.current_state_event_batch import CurrentStateEventBatch
+from zepben.evolve.streaming.data.set_current_states_status import SetCurrentStatesStatus
 
 
 class QueryNetworkStateService(QueryNetworkStateServiceServicer):
@@ -24,27 +26,68 @@ class QueryNetworkStateService(QueryNetworkStateServiceServicer):
 
     Attributes:
         on_get_current_states: An function that retrieves CurrentStateEvent objects within the specified time range.
+        on_current_states_status: A callback triggered when the response status of an event returned via `on_get_current_states` is received from the client.
+        on_processing_error: A function that takes a message and optional cause. Called when `on_current_states_status` raises an exception, or the
+          `SetCurrentStatesResponse` is for an unknown event status.
     """
 
-    def __init__(self, on_get_current_states: Callable[[datetime, datetime], AsyncGenerator[Iterable[CurrentStateEvent], None]]):
+    def __init__(
+        self,
+        on_get_current_states: Callable[[datetime, datetime], AsyncGenerator[CurrentStateEventBatch, None]],
+        on_current_states_status: Callable[[SetCurrentStatesStatus], None],
+        on_processing_error: Callable[[str, Optional[Exception]], None]
+    ):
         self.on_get_current_states = on_get_current_states
+        self.on_current_states_status = on_current_states_status
+        self.on_processing_error = on_processing_error
 
     async def getCurrentStates(self, request: GetCurrentStatesRequest, context) -> AsyncGenerator[GetCurrentStatesResponse, None]:
         """
         Handles the incoming request for retrieving current state events.
 
-        This method processes the provided GetCurrentStatesRequest, retrieves the
-        corresponding current state events using the callback function passed in
-        the constructor, and asynchronously returns a GetCurrentStatesResponse.
+        You shouldn't be calling this method directly, it will be invoked automatically via the gRPC engine. Each
+        `GetCurrentStatesRequest` retrieves the corresponding current state events using the `onGetCurrentStates`
+        callback function passed in the constructor, and asynchronously returns a `GetCurrentStatesResponse`.
+
         It acts as a bridge between the gRPC request and the business logic that fetches the current state events.
 
         Args:
             request: The request object containing parameters for fetching current state events,
-            including the time range for the query.
+              including the time range for the query.
             context: The gRPC context.
 
         Returns:
-           A stream of gRPC response message
+           A stream of gRPC response messages
         """
-        async for events in self.on_get_current_states(request.fromTimestamp.ToDatetime(), request.toTimestamp.ToDatetime()):
-            yield GetCurrentStatesResponse(messageId=request.messageId, event=[event.to_pb() for event in events])
+        async for batch in self.on_get_current_states(request.fromTimestamp.ToDatetime(), request.toTimestamp.ToDatetime()):
+            yield GetCurrentStatesResponse(messageId=batch.batch_id, event=[event.to_pb() for event in batch.events])
+
+    # noinspection PyUnresolvedReferences
+    async def reportBatchStatus(self, status_responses: AsyncGenerator[SetCurrentStatesResponse, None], context) -> empty_pb2.Empty:
+        """
+        Handles incoming status reports in response to an event batch returned via `getCurrentStates`.
+
+        You shouldn't be calling this method directly, it will be invoked automatically via the gRPC engine. Each
+        `SetCurrentStatesResponse` will trigger the `on_current_states_status` callback function passed in the constructor.
+
+        It acts as a bridge between the gRPC request and the business logic that validates/logs the status of event
+        handling. Any errors in this handling, or unexpected status message will trigger the `on_processing_error`
+        callback function passed in the constructor.
+
+        Args:
+            status_responses: The request object stream (yes you read that correctly that the request is a response...) containing the response to our current state batch.
+            context: The gRPC context.
+        """
+        async for status_response in status_responses:
+            status = SetCurrentStatesStatus.from_pb(status_response)
+            if status is not None:
+                try:
+                    self.on_current_states_status(status)
+                except Exception as e:
+                    message = f"Exception thrown in status response handler for batch `{status_response.messageId}`: {str(e)}"
+                    self.on_processing_error(message, e)
+            else:
+                self.on_processing_error(f"Failed to decode status response for batch `{status_response.messageId}`: Unsupported type {status_response.WhichOneof('status')}", None)
+
+        # noinspection PyUnresolvedReferences
+        return empty_pb2.Empty()

--- a/test/streaming/data/test_set_current_states_status.py
+++ b/test/streaming/data/test_set_current_states_status.py
@@ -2,60 +2,63 @@
 #  This Source Code Form is subject to the terms of the Mozilla Public
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
-from datetime import datetime
 
-from zepben.protobuf.ns.data.change_status_pb2 import BatchSuccessful as PBBatchSuccessful, ProcessingPaused as PBProcessingPaused, \
-    BatchFailure as PBBatchFailure, StateEventFailure as PBStateEventFailure, StateEventUnknownMrid as PBStateEventUnknownMrid, \
-    StateEventDuplicateMrid as PBStateEventDuplicateMrid, StateEventInvalidMrid as PBStateEventInvalidMrid, \
-    StateEventUnsupportedPhasing as PBStateEventUnsupportedPhasing
-from zepben.protobuf.ns.network_state_responses_pb2 import SetCurrentStatesResponse as PBSetCurrentStatesResponse
+from zepben.protobuf.ns.data.change_status_pb2 import StateEventFailure as PBStateEventFailure, StateEventInvalidMrid as PBStateEventInvalidMrid
 
-from zepben.evolve import datetime_to_timestamp, BatchSuccessful, ProcessingPaused, BatchFailure, StateEventInvalidMrid, StateEventFailure, \
-    StateEventUnknownMrid, StateEventDuplicateMrid, StateEventUnsupportedPhasing, SetCurrentStatesStatus
-
-
-def _test_state_event_failure_protobuf_conversion(pb: PBStateEventFailure, clazz: type):
-    status = StateEventFailure.from_pb(pb)
-    assert status.event_id == pb.eventId
-    assert isinstance(status, clazz)
-
-    # noinspection PyUnresolvedReferences
-    to_pb = status.to_pb()
-    assert to_pb.eventId == pb.eventId
-    assert to_pb.WhichOneof("reason") == pb.WhichOneof("reason")
+from zepben.evolve import BatchSuccessful, BatchFailure, StateEventInvalidMrid, StateEventFailure, \
+    StateEventUnknownMrid, StateEventDuplicateMrid, StateEventUnsupportedPhasing, SetCurrentStatesStatus, BatchNotProcessed
+from zepben.evolve.streaming.data.set_current_states_status import StateEventUnsupportedMrid
 
 
 class TestSetCurrentStatesStatus:
     invalid_mrid = PBStateEventFailure(eventId="event2", invalidMrid=PBStateEventInvalidMrid())
 
-    def test_batch_successful_protobuf_conversion(self):
-        pb = PBSetCurrentStatesResponse(messageId=1, success=PBBatchSuccessful())
-        status = SetCurrentStatesStatus.from_pb(pb)
+    #
+    # NOTE: We don't bother to check that the correct thing was put into the protobuf variants directly because it is
+    #       assumed that if the resulting object coming out the other side is correct then the intermediate one must
+    #       have been correct (good enough for us anyway).
+    #
 
-        assert status == BatchSuccessful(batch_id=1)
-        assert status.to_pb() == pb
+    def test_batch_successful_to_and_from_protobuf(self):
+        original = BatchSuccessful(1)
+        converted = SetCurrentStatesStatus.from_pb(original.to_pb())
 
-    def test_processing_paused_protobuf_conversion(self):
-        since = datetime.now()
-        pb = PBSetCurrentStatesResponse(messageId=1, paused=PBProcessingPaused(since=datetime_to_timestamp(since)))
-        status = SetCurrentStatesStatus.from_pb(pb)
+        assert isinstance(converted, type(original))
+        assert converted.batch_id == original.batch_id
 
-        assert status == ProcessingPaused(batch_id=1, since=since)
-        assert status.to_pb() == pb
+    def test_batch_failure_to_and_from_protobuf(self):
+        original = BatchFailure(1, True, (StateEventInvalidMrid("event1", "message1"), StateEventUnsupportedMrid("event2", "message2")))
+        converted = SetCurrentStatesStatus.from_pb(original.to_pb())
 
-    def test_batch_failure_protobuf_conversion(self):
-        pb = PBSetCurrentStatesResponse(messageId=1, failure=PBBatchFailure(partialFailure=True, failed=[self.invalid_mrid]))
-        status = SetCurrentStatesStatus.from_pb(pb)
+        assert isinstance(converted, type(original))
+        assert converted.batch_id == original.batch_id
+        assert converted.partial_failure == original.partial_failure
 
-        assert status == BatchFailure(batch_id=1, partial_failure=True, failures=(StateEventInvalidMrid(event_id="event2"),))
-        assert status.to_pb() == pb
+        assert [type(it) for it in converted.failures] == [StateEventInvalidMrid, StateEventUnsupportedMrid]
+        assert [it.event_id for it in converted.failures] == ["event1", "event2"]
+        assert [it.message for it in converted.failures] == ["message1", "message2"]
 
-    def test_state_event_failure_protobuf_conversion(self):
-        _test_state_event_failure_protobuf_conversion(PBStateEventFailure(eventId="event1", unknownMrid=PBStateEventUnknownMrid()), StateEventUnknownMrid)
-        _test_state_event_failure_protobuf_conversion(self.invalid_mrid, StateEventInvalidMrid)
-        _test_state_event_failure_protobuf_conversion(PBStateEventFailure(eventId="event3", duplicateMrid=PBStateEventDuplicateMrid()), StateEventDuplicateMrid)
-        _test_state_event_failure_protobuf_conversion(
-            PBStateEventFailure(eventId="event4", unsupportedPhasing=PBStateEventUnsupportedPhasing()),
-            StateEventUnsupportedPhasing)
+    def test_batch_not_processed_to_and_from_protobuf(self):
+        original = BatchNotProcessed(1)
+        converted = SetCurrentStatesStatus.from_pb(original.to_pb())
 
+        assert isinstance(converted, type(original))
+        assert converted.batch_id == original.batch_id
+
+    def test_state_event_failures_to_and_from_protobuf(self):
+        self._test_state_event_failure(StateEventUnknownMrid("event1", "unknown mrid message"))
+        self._test_state_event_failure(StateEventInvalidMrid("event2", "invalid mrid message"))
+        self._test_state_event_failure(StateEventDuplicateMrid("event3", "duplicate mrid message"))
+        self._test_state_event_failure(StateEventUnsupportedPhasing("event4", "unsupported phasing message"))
+        self._test_state_event_failure(StateEventUnsupportedMrid("event5", "unsupported mrid message"))
+
+        # Unknown protobuf types return None.
         assert StateEventFailure.from_pb(PBStateEventFailure()) is None
+
+    @staticmethod
+    def _test_state_event_failure(original: StateEventFailure):
+        converted = StateEventFailure.from_pb(original.to_pb())
+
+        assert isinstance(converted, type(original))
+        assert converted.event_id == original.event_id
+        assert converted.message == original.message

--- a/test/streaming/get/test_query_network_state_client.py
+++ b/test/streaming/get/test_query_network_state_client.py
@@ -3,21 +3,20 @@
 #  License, v. 2.0. If a copy of the MPL was not distributed with this
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from datetime import datetime, timedelta
-from typing import List, Callable, Generator, Iterable, Tuple
+from typing import List, Callable, Generator
 
 import grpc_testing
 import pytest
 from zepben.protobuf.ns import network_state_pb2
-from zepben.protobuf.ns.data.change_events_pb2 import CurrentStateEvent as PBCurrentStateEvent
 from zepben.protobuf.ns.network_state_responses_pb2 import GetCurrentStatesResponse
 
 from streaming.get.grpcio_aio_testing.mock_async_channel import async_testing_channel
 from streaming.get.mock_server import MockServer, GrpcRequest, GrpcResponse, StreamGrpc
-from zepben.evolve import PhaseCode, datetime_to_timestamp, SwitchStateEvent, SwitchAction, CurrentStateEvent, QueryNetworkStateClient
+from zepben.evolve import PhaseCode, datetime_to_timestamp, SwitchStateEvent, SwitchAction, CurrentStateEventBatch, QueryNetworkStateClient
 
 
-def _current_state_events_to_pb(current_state_events: Tuple[CurrentStateEvent, ...]) -> Tuple[PBCurrentStateEvent, ...]:
-    return tuple([event.to_pb() for event in current_state_events])
+def _current_state_batch_to_pb(batch: CurrentStateEventBatch) -> GetCurrentStatesResponse:
+    return GetCurrentStatesResponse(messageId=batch.batch_id, event=[event.to_pb() for event in batch.events])
 
 
 class TestQueryNetworkStateClient:
@@ -27,40 +26,32 @@ class TestQueryNetworkStateClient:
         channel = async_testing_channel(network_state_pb2.DESCRIPTOR.services_by_name.values(), grpc_testing.strict_real_time())
         self.mock_server = MockServer(channel, network_state_pb2.DESCRIPTOR.services_by_name['QueryNetworkStateService'])
         self.client = QueryNetworkStateClient(channel)
-        self.current_state_events = (
-            (SwitchStateEvent("event1", datetime.now(), "mrid1", SwitchAction.OPEN, PhaseCode.ABC),),
-            (SwitchStateEvent("event2", datetime.now(), "mrid1", SwitchAction.CLOSE, PhaseCode.ABN),),
-            (SwitchStateEvent("event3", datetime.now(), "mrid2", SwitchAction.CLOSE, PhaseCode.A),)
-        )
+        self.batches = [
+            CurrentStateEventBatch(1, [SwitchStateEvent("event1", datetime.now(), "mrid1", SwitchAction.OPEN, PhaseCode.ABC)]),
+            CurrentStateEventBatch(2, [SwitchStateEvent("event2", datetime.now(), "mrid1", SwitchAction.CLOSE, PhaseCode.ABN)]),
+            CurrentStateEventBatch(3, [SwitchStateEvent("event3", datetime.now(), "mrid2", SwitchAction.CLOSE, PhaseCode.A)])
+        ]
 
     @pytest.mark.asyncio
     async def test_get_current_states(self):
-        def mock_service(expected_from_timestamp: datetime, expected_to_timestamp: datetime, responses: Iterable[GrpcResponse]) -> List[
-            Callable[[GrpcRequest], Generator[GrpcResponse, None, None]]]:
+        query_id = 1
+        from_datetime = datetime.now()
+        to_datetime = datetime.now() + timedelta(days=1)
+        responses = [_current_state_batch_to_pb(it) for it in self.batches]
+
+        def mock_service() -> List[Callable[[GrpcRequest], Generator[GrpcResponse, None, None]]]:
             def process(request: GrpcRequest) -> Generator[GrpcResponse, None, None]:
+                assert request.messageId == query_id
+                assert request.fromTimestamp == datetime_to_timestamp(from_datetime)
+                assert request.toTimestamp == datetime_to_timestamp(to_datetime)
+
                 for response in responses:
                     yield response
-
-                assert request.fromTimestamp == expected_from_timestamp
-                assert request.toTimestamp == expected_to_timestamp
 
             return [process]
 
         async def client_test():
-            results = [response async for response in self.client.get_current_states(1, from_datetime, to_datetime)]
+            results = [response async for response in self.client.get_current_states(query_id, from_datetime, to_datetime)]
+            assert results == self.batches
 
-            expected_result = [event for batch in self.current_state_events for event in batch]
-            actual_result = [event for events in results for event in events]
-
-            assert actual_result == expected_result
-
-        from_datetime = datetime.now()
-        to_datetime = datetime.now() + timedelta(days=1)
-
-        response1 = GetCurrentStatesResponse(messageId=1, event=_current_state_events_to_pb(self.current_state_events[0]))
-        response2 = GetCurrentStatesResponse(messageId=1, event=_current_state_events_to_pb(self.current_state_events[1]))
-        response3 = GetCurrentStatesResponse(messageId=1, event=_current_state_events_to_pb(self.current_state_events[2]))
-
-        await self.mock_server.validate(client_test, [StreamGrpc('getCurrentStates',
-                                                                 mock_service(datetime_to_timestamp(from_datetime), datetime_to_timestamp(to_datetime),
-                                                                              [response1, response2, response3]))])
+        await self.mock_server.validate(client_test, [StreamGrpc('getCurrentStates', mock_service())])

--- a/test/streaming/get/test_query_network_state_service.py
+++ b/test/streaming/get/test_query_network_state_service.py
@@ -4,36 +4,76 @@
 #  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta
-from typing import Iterable
+from typing import List, Optional, Tuple
 
 import grpc
 import pytest
+from grpc.aio import AioRpcError
 from zepben.protobuf.ns.network_state_pb2_grpc import QueryNetworkStateServiceStub, add_QueryNetworkStateServiceServicer_to_server
 from zepben.protobuf.ns.network_state_requests_pb2 import GetCurrentStatesRequest
+from zepben.protobuf.ns.network_state_responses_pb2 import GetCurrentStatesResponse, SetCurrentStatesResponse
 
 from util import grpc_aio_server
-from zepben.evolve import datetime_to_timestamp, SwitchStateEvent, SwitchAction, CurrentStateEvent, QueryNetworkStateService, PhaseCode
+from zepben.evolve import datetime_to_timestamp, SwitchStateEvent, SwitchAction, QueryNetworkStateService, PhaseCode, CurrentStateEventBatch, \
+    SetCurrentStatesStatus, BatchNotProcessed, BatchSuccessful
 
 
 class TestQueryNetworkStateService:
     from_datetime = datetime.now()
     to_datetime = datetime.now() + timedelta(days=1)
-    current_state_events = (
-        (SwitchStateEvent("event1", datetime.now(), "mrid1", SwitchAction.OPEN, PhaseCode.ABC),),
-        (SwitchStateEvent("event2", datetime.now(), "mrid1", SwitchAction.CLOSE, PhaseCode.ABN),),
-        (SwitchStateEvent("event3", datetime.now(), "mrid2", SwitchAction.CLOSE, PhaseCode.A),)
-    )
+    events = [
+        SwitchStateEvent("event1", datetime.now(), "mrid1", SwitchAction.OPEN, PhaseCode.ABC),
+        SwitchStateEvent("event2", datetime.now(), "mrid1", SwitchAction.CLOSE, PhaseCode.ABN),
+        SwitchStateEvent("event3", datetime.now(), "mrid2", SwitchAction.CLOSE, PhaseCode.A)
+    ]
+    batches = [
+        CurrentStateEventBatch(1, [events[0], events[1]]),
+        CurrentStateEventBatch(1, [events[1], events[2]])
+    ]
+    error = RuntimeError("TEST ERROR!")
 
     @pytest.fixture
-    async def grpc_stub(self):
-        async def on_get_current_states(from_datetime: datetime, to_datetime: datetime) -> AsyncGenerator[Iterable[CurrentStateEvent], None]:
+    def capture_statuses(self) -> List[SetCurrentStatesStatus]:
+        return []
+
+    @pytest.fixture
+    def capture_errors(self) -> List[Tuple[str, Optional[Exception]]]:
+        return []
+
+    @pytest.fixture
+    def on_get_current_states_error(self) -> Optional[Exception]:
+        return None
+
+    @pytest.fixture
+    def on_report_current_states_error(self) -> Optional[Exception]:
+        return None
+
+    @pytest.fixture
+    async def grpc_stub(self, capture_statuses, capture_errors, on_get_current_states_error, on_report_current_states_error):
+        # Callbacks for the constructor.
+
+        async def on_get_current_states(from_datetime: datetime, to_datetime: datetime) -> AsyncGenerator[CurrentStateEventBatch, None]:
+            if on_get_current_states_error:
+                raise on_get_current_states_error
+
             assert from_datetime == self.from_datetime
             assert to_datetime == self.to_datetime
-            for event in self.current_state_events:
+
+            for event in self.batches:
                 yield event
 
+        def on_current_states_status(status: SetCurrentStatesStatus) -> None:
+            if on_report_current_states_error:
+                raise on_report_current_states_error
+            capture_statuses.append(status)
+
+        def on_processing_error(error: str, exception: Optional[Exception]) -> None:
+            capture_errors.append((error, exception))
+
+        # End callbacks for the constructor.
+
         server, host = grpc_aio_server()
-        add_QueryNetworkStateServiceServicer_to_server(QueryNetworkStateService(on_get_current_states), server)
+        add_QueryNetworkStateServiceServicer_to_server(QueryNetworkStateService(on_get_current_states, on_current_states_status, on_processing_error), server)
 
         await server.start()
         async with grpc.aio.insecure_channel(host) as channel:
@@ -43,16 +83,64 @@ class TestQueryNetworkStateService:
 
     @pytest.mark.asyncio
     async def test_get_current_states(self, grpc_stub):
-        request = GetCurrentStatesRequest(messageId=1, fromTimestamp=datetime_to_timestamp(self.from_datetime),
-                                          toTimestamp=datetime_to_timestamp(self.to_datetime))
+        request = GetCurrentStatesRequest(
+            messageId=1,
+            fromTimestamp=datetime_to_timestamp(self.from_datetime),
+            toTimestamp=datetime_to_timestamp(self.to_datetime)
+        )
         responses = [response async for response in grpc_stub.getCurrentStates(request)]
 
-        expected_result = [event for batch in self.current_state_events for event in batch]
-        actual_result = [event for response in responses for event in response.event]
+        def validate(response: GetCurrentStatesResponse, expected_batch: CurrentStateEventBatch):
+            assert response.messageId == expected_batch.batch_id
 
-        assert [a.messageId for a in responses] == [1, 1, 1]
-        assert [a.eventId for a in actual_result] == [e.event_id for e in expected_result]
-        assert [a.timestamp for a in actual_result] == [datetime_to_timestamp(e.timestamp) for e in expected_result]
-        assert [a.switch.mRID for a in actual_result] == [e.mrid for e in expected_result]
-        assert [a.switch.action for a in actual_result] == [e.action.value for e in expected_result]
-        assert [a.switch.phases for a in actual_result] == [e.phases.value[0] for e in expected_result]
+            assert [it.eventId for it in response.event] == [it.event_id for it in expected_batch.events]
+            assert [it.timestamp for it in response.event] == [datetime_to_timestamp(it.timestamp) for it in expected_batch.events]
+
+            expected_switch_events = [it for it in expected_batch.events if isinstance(it, SwitchStateEvent)]
+            assert [it.switch.mRID for it in response.event] == [it.mrid for it in expected_switch_events]
+            # Compare the int version in the response with the value of the SwitchAction enum.
+            assert [it.switch.action for it in response.event] == [it.action.value for it in expected_switch_events]
+            # Compare the int version in the response with the first value of the PhaseCode enum (it has multiple values).
+            assert [it.switch.phases for it in response.event] == [it.phases.value[0] for it in expected_switch_events]
+
+        assert len(responses) == len(self.batches)
+        for index, response in enumerate(responses):
+            validate(response, self.batches[index])
+
+    # noinspection PyTestParametrized
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('on_get_current_states_error', [error])
+    async def test_get_current_states_handles_error(self, grpc_stub):
+        with pytest.raises(AioRpcError) as e_info:
+            # noinspection PyUnusedLocal
+            responses = [response async for response in grpc_stub.getCurrentStates(GetCurrentStatesRequest())]
+
+        assert e_info.value.code() == grpc.StatusCode.UNKNOWN
+        assert str(self.error) in str(e_info.value)
+
+    @pytest.mark.asyncio
+    async def test_can_receive_status_responses(self, grpc_stub, capture_statuses):
+        # The requests for this call are actually response objects (deliberately).
+        requests = [BatchNotProcessed(1).to_pb(), BatchSuccessful(2).to_pb()]
+        await grpc_stub.reportBatchStatus(requests)
+
+        assert [it.batch_id for it in capture_statuses] == [1, 2]
+        assert [type(it) for it in capture_statuses] == [BatchNotProcessed, BatchSuccessful]
+
+    @pytest.mark.asyncio
+    async def test_calls_process_error_handler_with_unknown_status_responses(self, grpc_stub, capture_errors):
+        # The requests for this call are actually response objects (deliberately).
+        # Not sure if/how we can set this to something not supported like you would get from a future version, so just leave it blank.
+        requests = [SetCurrentStatesResponse(messageId=1)]
+        await grpc_stub.reportBatchStatus(requests)
+
+        assert capture_errors == [("Failed to decode status response for batch `1`: Unsupported type None", None)]
+
+    # noinspection PyTestParametrized
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('on_report_current_states_error', [error])
+    async def test_calls_process_error_handler_with_exception_in_status_handler(self, grpc_stub, capture_errors):
+        requests = [BatchSuccessful(1).to_pb()]
+        await grpc_stub.reportBatchStatus(requests)
+
+        assert capture_errors == [(f"Exception thrown in status response handler for batch `1`: {self.error}", self.error)]

--- a/test/streaming/mutations/test_update_network_state_service.py
+++ b/test/streaming/mutations/test_update_network_state_service.py
@@ -11,8 +11,8 @@ from zepben.protobuf.ns.network_state_pb2_grpc import add_UpdateNetworkStateServ
 from zepben.protobuf.ns.network_state_requests_pb2 import SetCurrentStatesRequest as PBSetCurrentStatesRequest
 
 from util import grpc_aio_server
-from zepben.evolve import PhaseCode, SwitchStateEvent, SwitchAction, CurrentStateEvent, SetCurrentStatesStatus, BatchSuccessful, ProcessingPaused, BatchFailure, \
-    UpdateNetworkStateService
+from zepben.evolve import PhaseCode, SwitchStateEvent, SwitchAction, CurrentStateEvent, SetCurrentStatesStatus, BatchSuccessful, BatchFailure, \
+    UpdateNetworkStateService, BatchNotProcessed
 
 
 class TestUpdateNetworkStateService:
@@ -24,8 +24,8 @@ class TestUpdateNetworkStateService:
 
     expected_results = {
         1: BatchSuccessful(batch_id=1),
-        2: ProcessingPaused(batch_id=2, since=datetime.now()),
-        3: BatchFailure(batch_id=3, partial_failure=False, failures=())
+        2: BatchFailure(batch_id=2, partial_failure=False, failures=()),
+        3: BatchNotProcessed(batch_id=3),
     }
 
     @pytest.fixture


### PR DESCRIPTION
# Description

### Breaking Changes
* Renamed `UpdateNetworkStateClient.SetCurrentStatesRequest` to `CurrentStateEventBatch`. You will need to update any uses, but the class members are the same.
* Removed `ProcessingPaused` current state response message as this functionality won't be supported.
* `QueryNetworkStateClient.get_current_states` now returns a `CurrentStateEventBatch` rather than just the events themselves.
* `QueryNetworkStateService.on_get_current_states` must now return a stream of `CurrentStateEventBatch` rather than just the events themselves.

### New Features
* Added `BatchNotProcessed` current state response. This is used to indicate a batch has been ignored, rather than just returning a `BatchSuccessful`.
* `QueryNetworkStateService` now supports `reportBatchStatus`, which requires two new constructor callbacks:
  * `on_current_states_status` - A callback triggered when the response status of an event returned via `on_get_current_states` is received from the client.
  * `on_processing_error` - A function that takes a message and optional cause. Called when `on_current_states_status` raises an exception, or the
    `SetCurrentStatesResponse` is for an unknown event status.

### Enhancements
* All `StateEventFailure` classes now have a `message` included to give more context to the error.

# Test Steps

Run the unit tests.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

See above.