### PR TITLE
Add FeederDirection.CONNECTOR for BusbarSection use

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
     mobile generator. To enable this, connectivity nodes are placed at the cut terminals. Once the connectivity nodes are in place any conducting equipment can
     be connected at them.
     __NOT CURRENTLY FULLY SUPPORTED BY TRACING__
+* Added FeederDirection.CONNECTOR, to be used by BusbarSections for their direction to differentiate from BOTH.
 
 ### Enhancements
 * Updated `NetworkConsumerClient`'s `get_equipment_for_container/s`,  `get_equipment_container`, `get_equipment_for_loop` and `get_all_loops`

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 deps = [
     "zepben.auth==0.12.1",
-    "zepben.protobuf==0.34.0b1"
+    "zepben.protobuf==0.34.1"
 ]
 
 test_deps = [

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r") as fh:
 
 deps = [
     "zepben.auth==0.12.1",
-    "zepben.protobuf==0.34.1"
+    "zepben.protobuf==0.34.0"
 ]
 
 test_deps = [

--- a/src/zepben/evolve/services/network/tracing/feeder/feeder_direction.py
+++ b/src/zepben/evolve/services/network/tracing/feeder/feeder_direction.py
@@ -37,7 +37,7 @@ class FeederDirection(Enum):
     CONNECTOR = 4
     """
     The terminal belongs to a Connector that is modelled with only a single terminal.
-    CONNECTOR will match direction up UPSTREAM, DOWNSTREAM, and BOTH, however it exists
+    CONNECTOR will match direction UPSTREAM, DOWNSTREAM, and BOTH, however it exists
     to differentiate it from BOTH which is used to indicate loops on the feeder. This
     however means you connected tell if a terminal with CONNECTOR is part of a loop
     directly, you need to check its connected terminals and check for BOTH to determine
@@ -52,7 +52,7 @@ class FeederDirection(Enum):
         :param other: The `FeederDirection` to check.
         :return: `True` if this is `BOTH` and other is not `NONE`, or if the directions are the same, otherwise `False`
         """
-        if self is FeederDirection.BOTH:
+        if self in (FeederDirection.BOTH, FeederDirection.CONNECTOR):
             return other is not FeederDirection.NONE
         else:
             return self is other
@@ -64,6 +64,9 @@ class FeederDirection(Enum):
         :param other: The `FeederDirection` to add.
         :return: The resulting `FeederDirection` with `other` added.
         """
+        if self == FeederDirection.CONNECTOR:
+            return FeederDirection.CONNECTOR
+
         return FeederDirection(self.value | other.value)
 
     def __sub__(self, other):
@@ -73,6 +76,9 @@ class FeederDirection(Enum):
         :param other: The `FeederDirection` to remove.
         :return: The resulting `FeederDirection` with `other` removed.
         """
+        if self == FeederDirection.CONNECTOR:
+            return FeederDirection.CONNECTOR
+
         return FeederDirection(self.value - (self.value & other.value))
 
     def __invert__(self):
@@ -80,7 +86,7 @@ class FeederDirection(Enum):
             return FeederDirection.DOWNSTREAM
         elif self == FeederDirection.DOWNSTREAM:
             return FeederDirection.UPSTREAM
-        elif self == FeederDirection.BOTH:
+        elif self in (FeederDirection.BOTH, FeederDirection.CONNECTOR):
             return FeederDirection.NONE
         else:  # lif self == FeederDirection.NONE:
             return FeederDirection.BOTH

--- a/src/zepben/evolve/services/network/tracing/feeder/feeder_direction.py
+++ b/src/zepben/evolve/services/network/tracing/feeder/feeder_direction.py
@@ -34,6 +34,16 @@ class FeederDirection(Enum):
     to trace upstream towards the feeder head, or downstream away from the feeder head.
     """
 
+    CONNECTOR = 4
+    """
+    The terminal belongs to a Connector that is modelled with only a single terminal.
+    CONNECTOR will match direction up UPSTREAM, DOWNSTREAM, and BOTH, however it exists
+    to differentiate it from BOTH which is used to indicate loops on the feeder. This
+    however means you connected tell if a terminal with CONNECTOR is part of a loop
+    directly, you need to check its connected terminals and check for BOTH to determine
+    if it is in a loop.
+    """
+
     # todo replace .has(
     def __contains__(self, other):
         """

--- a/test/services/network/tracing/feeder/test_feeder_direction.py
+++ b/test/services/network/tracing/feeder/test_feeder_direction.py
@@ -28,6 +28,11 @@ class TestFeederDirection:
         assert FeederDirection.DOWNSTREAM in FeederDirection.BOTH
         assert FeederDirection.BOTH in FeederDirection.BOTH
 
+        assert FeederDirection.NONE not in FeederDirection.CONNECTOR
+        assert FeederDirection.UPSTREAM in FeederDirection.CONNECTOR
+        assert FeederDirection.DOWNSTREAM in FeederDirection.CONNECTOR
+        assert FeederDirection.BOTH in FeederDirection.CONNECTOR
+
     def test_plus(self):
         assert FeederDirection.NONE + FeederDirection.NONE == FeederDirection.NONE
         assert FeederDirection.NONE + FeederDirection.UPSTREAM == FeederDirection.UPSTREAM
@@ -48,6 +53,11 @@ class TestFeederDirection:
         assert FeederDirection.BOTH + FeederDirection.UPSTREAM == FeederDirection.BOTH
         assert FeederDirection.BOTH + FeederDirection.DOWNSTREAM == FeederDirection.BOTH
         assert FeederDirection.BOTH + FeederDirection.BOTH == FeederDirection.BOTH
+
+        assert FeederDirection.CONNECTOR + FeederDirection.NONE == FeederDirection.CONNECTOR
+        assert FeederDirection.CONNECTOR + FeederDirection.UPSTREAM == FeederDirection.CONNECTOR
+        assert FeederDirection.CONNECTOR + FeederDirection.DOWNSTREAM == FeederDirection.CONNECTOR
+        assert FeederDirection.CONNECTOR + FeederDirection.BOTH == FeederDirection.CONNECTOR
 
     def test_minus(self):
         assert FeederDirection.NONE - FeederDirection.NONE == FeederDirection.NONE
@@ -70,8 +80,14 @@ class TestFeederDirection:
         assert FeederDirection.BOTH - FeederDirection.DOWNSTREAM == FeederDirection.UPSTREAM
         assert FeederDirection.BOTH - FeederDirection.BOTH == FeederDirection.NONE
 
+        assert FeederDirection.CONNECTOR - FeederDirection.NONE == FeederDirection.CONNECTOR
+        assert FeederDirection.CONNECTOR - FeederDirection.UPSTREAM == FeederDirection.CONNECTOR
+        assert FeederDirection.CONNECTOR - FeederDirection.DOWNSTREAM == FeederDirection.CONNECTOR
+        assert FeederDirection.CONNECTOR - FeederDirection.BOTH == FeederDirection.CONNECTOR
+
     def test_not(self):
         assert ~FeederDirection.NONE == FeederDirection.BOTH
         assert ~FeederDirection.UPSTREAM == FeederDirection.DOWNSTREAM
         assert ~FeederDirection.DOWNSTREAM == FeederDirection.UPSTREAM
         assert ~FeederDirection.BOTH == FeederDirection.NONE
+        assert ~FeederDirection.CONNECTOR == FeederDirection.NONE


### PR DESCRIPTION
Supports FeederDirection.CONNECTOR to provide support for BusbarSections that now have only one terminal

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

I sincerely hope this won't break anything with older EWBs.
