### PR TITLE
Use new release flow when releasing

### DIFF
--- a/.github/workflows/python-lib-release.yml
+++ b/.github/workflows/python-lib-release.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   run:
-    uses: zepben/.github/.github/workflows/python-lib-release-with-docs.yml@main
+    uses: zepben/.github/.github/workflows/python-lib-release.yml@main
     with:
       private: false
       product-key: "python-sdk"   # Must be unique


### PR DESCRIPTION
# Description

Just run a proper flow for releases. It was updated to work with the new Python build project structure properly.